### PR TITLE
WIP: Add a leanpubr preview/publish script

### DIFF
--- a/scripts/preview-leanpub.r
+++ b/scripts/preview-leanpub.r
@@ -11,6 +11,11 @@
 # -s jhu/jhudsl_course_template \
 # -a BLAHBLAHBLAH
 
+# Setting up your API Key
+# If you don't want to directly supply your API Key everytime, you can set it
+# to your environment using the following command. Where `BLAHBLAHBLAH` if the
+# API Key you obtained from your Leanpub: https://leanpub.com/user_dashboard/api_key
+# Sys.setenv("LEANPUB_API_KEY" = "BLAHBLAHBLAH")
 
 # Establish base dir
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
@@ -40,6 +45,15 @@ option_list <- list(
 
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
+
+# If no API key is supplied, try to grab it from the .env
+if (is.null(opt$api_key)) {
+ opt$api_key <- Sys.getenv('LEANPUB_API_KEY')
+  if (opt$api_key == "") {
+  stop("Tried to obtain the API Key from Sys.getenv('LEANPUB_API_KEY') but it
+  was not set. Use Sys.setenv("LEANPUB_API_KEY" = "BLAHBLAHBLAH") to set it")
+  }
+}
 
 # Publish if --publish was used, otherwise do a preview
 if (opt$publish) {

--- a/scripts/preview-leanpub.r
+++ b/scripts/preview-leanpub.r
@@ -1,0 +1,50 @@
+#!/usr/bin/env Rscript
+#
+# When given a Publishes to a Leanpub book
+#
+# Candace Savonen - jhudsl
+# 2021
+#
+# Command line example:
+#
+# Rscript publish-leanpub.R \
+# -s jhu/jhudsl_course_template
+# -a BLAHBLAHBLAH1234
+
+# Establish base dir
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+
+# Load library:
+library(optparse)
+
+#--------------------------------Set up options--------------------------------#
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-s", "--slug"), type = "character",
+    default = NULL, help = "Supply your Leanpub slug. Example: jhu/jhudsl_course_template",
+    metavar = "character"
+    ),
+  make_option(
+    opt_str = c("-a", "--api_key"), type = "character",
+    default = NULL, help = "Supply your Leanpub API key. Can find it here: https://leanpub.com/user_dashboard/api_key",
+    metavar = "character"
+  ),
+  make_option(
+    opt_str = c("--publish"), action = "store_true",
+    default = FALSE, help = "If TRUE, will publish to Leanpub. Default it so make a preview only.",
+    metavar = "character"
+  )
+)
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# Publish if --publish was used, otherwise do a preview
+if (opt$publish) {
+  # Publish it!
+  leanpubr::lp_publish(opt$slug, api_key = opt$api_key)
+} else {
+  # Do a preview
+  leanpubr::lp_preview(opt$slug, api_key = opt$api_key)
+}

--- a/scripts/preview-leanpub.r
+++ b/scripts/preview-leanpub.r
@@ -7,9 +7,10 @@
 #
 # Command line example:
 #
-# Rscript publish-leanpub.R \
-# -s jhu/jhudsl_course_template
-# -a BLAHBLAHBLAH1234
+# Rscript scripts/preview-leanpub.R \
+# -s jhu/jhudsl_course_template \
+# -a BLAHBLAHBLAH
+
 
 # Establish base dir
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))

--- a/scripts/preview-leanpub.r
+++ b/scripts/preview-leanpub.r
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 #
-# When given a Publishes to a Leanpub book
+# Publishes the Git Repo to a Leanpub book
 #
 # Candace Savonen - jhudsl
 # 2021


### PR DESCRIPTION
### Summary 

This is a first step toward: #11 
This script we can use to publish or preview items to Leanpub. I still need to add instructions for this on CONTRIBUTING.md. 

This would be the basic usage: 
```
Rscript scripts/preview-leanpub.R \
-s jhu/jhudsl_course_template \
-a <Whatever your API Key is here>
```
Or you can set your API key to the environment so leanpubr will grab it. 

Currently, I'm having troubles getting the preview to work -- I wonder if its because this will only work if the course is already published? Not sure. 