### PR TITLE
Add github actions for styling code and spell checking automatically

### DIFF
--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -1,0 +1,60 @@
+
+# This code was originally written by Josh Shapiro and Candace Savonen
+# for the Childhood Cancer Data Lab an initiative of Alexs Lemonade Stand Foundation.
+# https://github.com/AlexsLemonade/refinebio-examples/blob/33cdeff66d57f9fe8ee4fcb5156aea4ac2dce07f/.github/workflows/style-and-sp-check.yml#L1
+
+# Adapted for this jhudsl repository by Candace Savonen Apr 2021
+
+name: Style and spell check R markdowns
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  pull_request:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "style and check"
+  style-n-check:
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/tidyverse:4.0.2
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+        # What branch to commit to: the one from the pull request
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install packages
+        run: Rscript -e "install.packages(c('styler', 'spelling'))"
+
+      - name: Run spell check
+        id: spell_check_run
+        run: |
+          results=$(Rscript "scripts/spell-check.R")
+          echo "::set-output name=sp_chk_results::$results"
+          cat spell_check_results.tsv
+      - name: Archive spelling errors
+        uses: actions/upload-artifact@v2
+        with:
+          name: spell-check-results
+          path: spell_check_results.tsv
+
+      # If there are too many spelling errors, this will stop the workflow
+      - name: Check spell check results - fail if too many errors
+        if: ${{ steps.spell_check_run.outputs.sp_chk_results > 3 }}
+        run: exit 1
+
+      - name: Run styler
+        run: Rscript -e "styler::style_file(list.files(pattern = 'Rmd$', recursive = TRUE, full.names = TRUE));warnings()"
+
+      - name: Commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add \*.Rmd
+          git commit -m 'Style Rmds' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -1,6 +1,6 @@
 
 # This code was originally written by Josh Shapiro and Candace Savonen
-# for the Childhood Cancer Data Lab an initiative of Alexs Lemonade Stand Foundation.
+# for the Childhood Cancer Data Lab, an initiative of Alexs Lemonade Stand Foundation.
 # https://github.com/AlexsLemonade/refinebio-examples/blob/33cdeff66d57f9fe8ee4fcb5156aea4ac2dce07f/.github/workflows/style-and-sp-check.yml#L1
 
 # Adapted for this jhudsl repository by Candace Savonen Apr 2021

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 .rstudio
 .bash_history
 
+spell_check_results.tsv
+
 

--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -28,9 +28,9 @@ if (!dir.exists(output_dir)) {
 ```
 
 ```{r}
-iris %>% 
-  ggplot(aes(Sepal.Length, Sepal.Width, color = Species)) + 
-  geom_point() + 
+iris %>%
+  ggplot(aes(Sepal.Length, Sepal.Width, color = Species)) +
+  geom_point() +
   theme_bw()
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This template includes all of the files that you need to get started creating your course in [R Markdown](https://rmarkdown.rstudio.com/) using the [bookdown package](https://bookdown.org/) and/or Leanpub.
 
-TODO: This will need to be revised if/when we split into separate bookdown Leanpub repositories. 
+TODO: This will need to be revised if/when we split into separate bookdown Leanpub repositories.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -67,13 +67,39 @@ TODO: Add more information about how to start a new image and add packages to ex
 
 TODO: How to add and use citations
 
-## Spell check
-
-TODO: Can have github actions run this for us.
-
 ## Style guide
 
-TODO: Are there any standards we wanna keep to
+Github actions will run the [`styler` package to all style R in all Rmds](https://github.com/jhudsl/ITCR_Course_Template_Bookdown/.github/workflows/style-and-sp-check.yml) whenever a pull request to the `main` branch is filed.
+Style changes will automatically be committed back to your branch.
+
+## Spell check
+
+Github actions will automatically [run a spell check on all Rmds](https://github.com/jhudsl/ITCR_Course_Template_Bookdown/.github/workflows/style-and-sp-check.yml) whenever a pull request to the `main` branch is filed.
+
+It will fail if there are more than 2 spelling errors and you'll need to resolve those before being able to merge your pull request.
+
+To resolve those spelling errors, go to this repository's `Actions` tab.
+Then, click on the GitHub action from the PR you just submitted.
+Scroll all the way down to `Artifacts` and click `spell-check-results`.
+This will download a zip file with a TSV that lists all the spelling errors.
+
+Some of these errors may be things that the spell check doesn't recognize for example: `ITCR`.
+If it's a 'word' the spell check should recognize, you'll need to add this to the dictionary.
+
+Go to the `resources/dictionary.txt` file.
+Open the file and add the new 'word' to its appropriate place (the words are in alphabetical order).
+Then commit the changes to `resources/dictionary.txt` to your branch and this should make the spell check status check pass.
+
+### Running spell check and styler manually
+
+If you are using the [Docker container](#setting-up-docker-image), or otherwise have the `spelling` and `styler` package installed, you can run spell check and styling locally on all Rmds by running this:
+
+```
+Rscript scripts/spell-check.R
+```
+
+The spell check results file will be saved to a file called `spell_check_results.tsv`.
+This file should not be pushed to the github repository (it is in the gitignore so this shouldn't happen).
 
 ## Bookdown Rendering
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,8 +14,8 @@ description: "Description about Course/Book."
 ```{r include=FALSE}
 # automatically create a bib database for R packages
 knitr::write_bib(c(
-  .packages(), 'bookdown', 'knitr', 'rmarkdown'
-), 'packages.bib')
+  .packages(), "bookdown", "knitr", "rmarkdown"
+), "packages.bib")
 ```
 
 # About this Course {-}

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -1,0 +1,5 @@
+ITCR
+itcrtraining
+ITN
+Markua
+www

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -1,0 +1,32 @@
+#!/usr/bin/env Rscript
+#
+# Run spell check and save results
+
+library(magrittr)
+
+# Find .git root directory
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+
+# Read in dictionary
+dictionary <- readLines(file.path(root_dir, 'components', 'dictionary.txt'))
+
+# Add mysterious emoji joining character
+dictionary <- c(dictionary, spelling::spell_check_text("⬇️")$word)
+
+# Only declare `.Rmd` files
+files <- list.files(pattern = 'Rmd$', recursive = TRUE, full.names = TRUE)
+
+# Remove the template from the spell check 
+files <- grep('template_example.Rmd', files, invert = TRUE, value = TRUE)
+
+# Run spell check
+sp_errors <- spelling::spell_check_files(files, ignore = dictionary) %>%
+  data.frame() %>%
+  tidyr::unnest(cols = found) %>%
+  tidyr::separate(found, into = c("file", "lines"), sep = ":")
+
+# Print out how many spell check errors
+write(nrow(sp_errors), stdout())
+
+# Save spell errors to file temporarily
+readr::write_tsv(sp_errors, 'spell_check_results.tsv')

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -1,5 +1,11 @@
 #!/usr/bin/env Rscript
-#
+
+# This code was originally written by Josh Shapiro and Candace Savonen
+# for the Childhood Cancer Data Lab an initiative of Alexs Lemonade Stand Foundation.
+# https://github.com/AlexsLemonade/refinebio-examples/blob/33cdeff66d57f9fe8ee4fcb5156aea4ac2dce07f/.github/workflows/style-and-sp-check.yml#L1
+
+# Adapted for this jhudsl repository by Candace Savonen Apr 2021
+
 # Run spell check and save results
 
 library(magrittr)
@@ -8,7 +14,7 @@ library(magrittr)
 root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 
 # Read in dictionary
-dictionary <- readLines(file.path(root_dir, 'components', 'dictionary.txt'))
+dictionary <- readLines(file.path(root_dir, 'resources', 'dictionary.txt'))
 
 # Add mysterious emoji joining character
 dictionary <- c(dictionary, spelling::spell_check_text("⬇️")$word)
@@ -16,7 +22,7 @@ dictionary <- c(dictionary, spelling::spell_check_text("⬇️")$word)
 # Only declare `.Rmd` files
 files <- list.files(pattern = 'Rmd$', recursive = TRUE, full.names = TRUE)
 
-# Remove the template from the spell check 
+# Remove the template from the spell check
 files <- grep('template_example.Rmd', files, invert = TRUE, value = TRUE)
 
 # Run spell check

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -22,9 +22,6 @@ dictionary <- c(dictionary, spelling::spell_check_text("⬇️")$word)
 # Only declare `.Rmd` files
 files <- list.files(pattern = 'Rmd$', recursive = TRUE, full.names = TRUE)
 
-# Remove the template from the spell check
-files <- grep('template_example.Rmd', files, invert = TRUE, value = TRUE)
-
 # Run spell check
 sp_errors <- spelling::spell_check_files(files, ignore = dictionary) %>%
   data.frame() %>%


### PR DESCRIPTION
### Summary 

This PR uses the `spelling` and `styler` packages so that every time a PR is filed, spell check and styling of the code is ran and then committed back to the branch that the PR was made from. 

This code set up borrowed from https://github.com/AlexsLemonade/refinebio-examples so I tried to make sure appropriate credit is given. https://github.com/AlexsLemonade/refinebio-examples/blob/staging/.github/workflows/style-and-sp-check.yml