### PR TITLE
GHA: Transfer docs/ folder to Leanpub repo

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -9,7 +9,8 @@ name: Copy docs/ folder from Bookdown to Leanpub repo
 
 # This workflow will run when there are changes to exercise notebooks in THIS repo
 on:
-  pull_request: [ cansavvy/transfer-docs-gha ]
+  pull_request:
+    branches: [ cansavvy/transfer-docs-gha ]
   push:
     branches: [ master ]
     # trigger on changes to exercise notebooks, but not `solved` notebooks

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -32,31 +32,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
-          # the url from this repo where files will be downloaded from
-          base_url=https://${GH_TOKEN}@raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/heads/}
-          echo $base_url
+          apt-get install subversion
 
-          # urls for the files in docs/
-          list_url=(ls -R ${base_url}/docs/*)
-          echo $list_url
-
-          # get the file list
-          file_paths=$(curl --fail -s ${list_url}) || echo "Error getting docs/ file at ${list_url}"
-
-          # error if the docs/ is empty
-          [[ -z $file_paths ]] && echo "docs/ folder is empty." && exit 1
-
-          # remove old docs/ files
+          # remove old docs/ files and folder
           rm docs/*
+          rmdir docs
 
-          # get new exercise files and put them in the right place
-          for path in $file_paths
-          do
-            # test that the path is to an md file, error if not
-            [[ $path != *.md ]] && echo "'$path' is not an .md file." && exit 1
-            echo $path
-            curl --fail -s ${base_url}/${path} > ${path}
-          done
+          # Get list of files
+          svn export https://github.com/jhudsl/ITCR_Course_Template_Bookdown.git/branches/${GITHUB_REF}/docs
 
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -9,9 +9,15 @@ name: Copy docs/* folder from Bookdown to Leanpub repo
 
 # This workflow will run when there are changes to docs/ files in THIS repo
 on:
+  # Only run after the render finishes running
+  workflow_run:
+    workflows: [ "Build, Render, and Push" ]
+    branches: [ main ]
+    types:
+      - completed
+  # Only if docs files are changed
   push:
-    branches: [ master, cansavvy/transfer-docs-gha]
-    # trigger on changes to exercise notebooks, but not `solved` notebooks
+    branches: [ main ]
     paths:
      - 'docs/*'
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -12,8 +12,8 @@ on:
   push:
     branches: [ master, cansavvy/transfer-docs-gha]
     # trigger on changes to exercise notebooks, but not `solved` notebooks
-    #paths:
-    # - 'docs/*'
+    paths:
+     - 'docs/*'
 
 jobs:
   file-bookdown-pr:

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -4,13 +4,13 @@
 
 # Adapted for this jhudsl repository by Candace Savonen Apr 2021
 
-name: Copy docs/ folder from Bookdown to Leanpub repo
+name: Copy docs/* folder from Bookdown to Leanpub repo
 # Copy rendered notebooks to Leanpub repo
 
 # This workflow will run when there are changes to exercise notebooks in THIS repo
 on:
   pull_request:
-    branches: [ cansavvy/transfer-docs-gha ]
+    branches: [ master ]
   push:
     branches: [ master ]
     # trigger on changes to exercise notebooks, but not `solved` notebooks
@@ -40,8 +40,9 @@ jobs:
           list_url=ls ${base_url}/docs/
           echo $list_url
 
-          # get the exercise file list
+          # get the file list
           file_paths=$(curl --fail -s ${list_url}) || echo "Error getting docs/ file at ${list_url}"
+
           # error if the docs/ is empty
           [[ -z $exercise_paths ]] && echo "docs/ folder is empty." && exit 1
 
@@ -61,7 +62,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}
           commit-message: Copy docs/ files from Bookdown repository
           signoff: false
           branch: auto_copy_rendered_files

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -38,7 +38,7 @@ jobs:
           rm -r docs
 
           # Get list of files
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF##*/}/docs
+          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/docs
 
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -25,12 +25,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: jhudsl/ITCR_Course_Template_Leanpub
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN }}
 
       - name: Get docs/ from Bookdown repo
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
           # the url from this repo where files will be downloaded from
           base_url=https://${GH_TOKEN}@raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/heads/}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -34,7 +34,9 @@ jobs:
         run: |
           # the url from this repo where files will be downloaded from
           base_url=https://${GH_TOKEN}@raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/heads/}
-          # urls for
+          echo $base_url
+
+          # urls for the files in docs/
           list_url=(ls -R ${base_url}/docs/*)
           echo $list_url
 
@@ -42,7 +44,7 @@ jobs:
           file_paths=$(curl --fail -s ${list_url}) || echo "Error getting docs/ file at ${list_url}"
 
           # error if the docs/ is empty
-          [[ -z $exercise_paths ]] && echo "docs/ folder is empty." && exit 1
+          [[ -z $file_paths ]] && echo "docs/ folder is empty." && exit 1
 
           # remove old docs/ files
           rm docs/*

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -12,8 +12,8 @@ on:
   push:
     branches: [ master, cansavvy/transfer-docs-gha]
     # trigger on changes to exercise notebooks, but not `solved` notebooks
-    paths:
-     - 'docs/*'
+    #paths:
+    # - 'docs/*'
 
 jobs:
   file-bookdown-pr:

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
-          apt-get install subversion
+          sudo apt-get install subversion
 
           # remove old docs/ files and folder
           rm docs/*

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -38,7 +38,7 @@ jobs:
           rm -r docs
 
           # Get list of files
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF}/docs
+          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF##*/}/docs
 
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -9,6 +9,7 @@ name: Copy docs/ folder from Bookdown to Leanpub repo
 
 # This workflow will run when there are changes to exercise notebooks in THIS repo
 on:
+  pull_request: [ cansavvy/transfer-docs-gha ]
   push:
     branches: [ master ]
     # trigger on changes to exercise notebooks, but not `solved` notebooks

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -1,0 +1,80 @@
+# This code was originally written by Josh Shapiro
+# for the Childhood Cancer Data Lab, an initiative of Alexs Lemonade Stand Foundation.
+# https://github.com/AlexsLemonade/exercise-notebook-answers
+
+# Adapted for this jhudsl repository by Candace Savonen Apr 2021
+
+name: Copy docs/ folder from Bookdown to Leanpub repo
+# Copy rendered notebooks to Leanpub repo
+
+# This workflow will run when there are changes to exercise notebooks in THIS repo
+on:
+  push:
+    branches: [ master ]
+    # trigger on changes to exercise notebooks, but not `solved` notebooks
+    paths:
+     - 'docs/*'
+
+jobs:
+  file-bookdown-pr:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code from Leanpub repo
+        uses: actions/checkout@v2
+        with:
+          repository: jhudsl/ITCR_Course_Template_Leanpub
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get docs/ from Bookdown repo
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # the url from this repo where files will be downloaded from
+          base_url=https://${GH_TOKEN}@raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/heads/}
+          # url for exercise-list.txt
+          list_url=ls ${base_url}/docs/
+          echo $list_url
+
+          # get the exercise file list
+          file_paths=$(curl --fail -s ${list_url}) || echo "Error getting docs/ file at ${list_url}"
+          # error if the docs/ is empty
+          [[ -z $exercise_paths ]] && echo "docs/ folder is empty." && exit 1
+
+          # remove old docs/ files
+          rm docs/*
+
+          # get new exercise files and put them in the right place
+          for path in $file_paths
+          do
+            # test that the path is to an Rmd file, error if not
+            [[ $path != *.md ]] && echo "'$path' is not an .md file." && exit 1
+            echo $path
+            curl --fail -s ${base_url}/${path} > ${path}
+          done
+
+      - name: Create PR with rendered docs files
+        uses: peter-evans/create-pull-request@v3
+        id: cpr
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Copy docs/ files from Bookdown repository
+          signoff: false
+          branch: auto_copy_rendered_files
+          delete-branch: true
+          title: 'GHA: Automated transfer of docs/ from Bookdown repository'
+          body: |
+            ### Description:
+            This PR auto-generated from github actions
+              - Copy the bookdown rendered files in docs/ from Bookdown repository
+          labels: |
+            automated
+          reviewers: $GITHUB_ACTOR
+
+      # Write out PR info
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: jhudsl/ITCR_Course_Template_Leanpub
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GIT_TOKEN }}
 
       - name: Get docs/ from Bookdown repo
         shell: bash
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GIT_TOKEN }}
           commit-message: Copy docs/ files from Bookdown repository
           signoff: false
           branch: auto_copy_rendered_files

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -35,8 +35,7 @@ jobs:
           sudo apt-get install subversion
 
           # remove old docs/ files and folder
-          rm docs/*
-          rmdir docs
+          rm -r docss
 
           # Get list of files
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF}/docs

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get install subversion
 
           # remove old docs/ files and folder
-          rm -r docss
+          rm -r docs
 
           # Get list of files
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF}/docs

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -7,12 +7,10 @@
 name: Copy docs/* folder from Bookdown to Leanpub repo
 # Copy rendered notebooks to Leanpub repo
 
-# This workflow will run when there are changes to exercise notebooks in THIS repo
+# This workflow will run when there are changes to docs/ files in THIS repo
 on:
-  pull_request:
-    branches: [ master ]
   push:
-    branches: [ master ]
+    branches: [ master, cansavvy/transfer-docs-gha]
     # trigger on changes to exercise notebooks, but not `solved` notebooks
     paths:
      - 'docs/*'
@@ -36,8 +34,8 @@ jobs:
         run: |
           # the url from this repo where files will be downloaded from
           base_url=https://${GH_TOKEN}@raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/heads/}
-          # url for exercise-list.txt
-          list_url=ls ${base_url}/docs/
+          # urls for
+          list_url=(ls -R ${base_url}/docs/*)
           echo $list_url
 
           # get the file list
@@ -52,7 +50,7 @@ jobs:
           # get new exercise files and put them in the right place
           for path in $file_paths
           do
-            # test that the path is to an Rmd file, error if not
+            # test that the path is to an md file, error if not
             [[ $path != *.md ]] && echo "'$path' is not an .md file." && exit 1
             echo $path
             curl --fail -s ${base_url}/${path} > ${path}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -39,7 +39,7 @@ jobs:
           rmdir docs
 
           # Get list of files
-          svn export https://github.com/jhudsl/ITCR_Course_Template_Bookdown.git/branches/${GITHUB_REF}/docs
+          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF}/docs
 
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3

--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -14,3 +14,4 @@ The course is intended for
 **Curriculum:**  
 This course will feature 
 The curriculum will also cover 
+

--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -8,9 +8,9 @@ output: html_document
 ## Motivation
 This course will cover 
 
-**Target Audience:**  
+## Target Audience:
 The course is intended for 
 
-**Curriculum:**  
+## Curriculum: 
 This course will feature 
 The curriculum will also cover 

--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -14,4 +14,3 @@ The course is intended for
 **Curriculum:**  
 This course will feature 
 The curriculum will also cover 
-


### PR DESCRIPTION
This is toward completing https://github.com/jhudsl/ITCR_Course_Template_Leanpub/issues/16

If it works right, it should file a PR over on the Leanpub PR that adds the docs files from here. The idea being that as changes are made to content here, we want it copied over to the Leanpub repo. 

Once I have this part working the last part I need to make sure, is that the render gha completes before this gha runs. Will have to look into that. 