### PR TITLE
Set URL-checker to ignore https://jhudatascience.org/ITCR_{Course_Name}}

### DIFF
--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -32,4 +32,4 @@ jobs:
         uses: paramt/url-checker@master
         with:
           files: "${{ steps.get_rmds.outputs.all_files }}"
-          blacklist: "${{ steps.get_rmds.outputs.all_files }},01-intro.md,about.md,doi2bib.org"
+          blacklist: "${{ steps.get_rmds.outputs.all_files }},01-intro.md,about.md,doi2bib.org,https://jhudatascience.org/ITCR_{Course_Name}}"


### PR DESCRIPTION
There was some confusion about the the templated URL `https://jhudatascience.org/ITCR_{Course_Name}}` in the README causing url-checker to fail: https://github.com/jhudsl/ITCR_Course_Template_Bookdown/pull/59#issuecomment-825938682

So I've added it to the url-checker's ignore list. But when this repo is used a template, someone will have to remember to change that URL (it is listed in the issues from issue-filer). 