### PR TITLE
Turn off leanpub transfer for now

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -9,12 +9,13 @@ name: Copy docs/* folder from Bookdown to Leanpub repo
 
 # This workflow will run when there are changes to docs/ files in THIS repo
 on:
+  workflow_dispatch:
   # Only run after the render finishes running
-  workflow_run:
-    workflows: [ "Build, Render, and Push" ]
-    branches: [ main ]
-    types:
-      - completed
+  #workflow_run:
+  #  workflows: [ "Build, Render, and Push" ]
+  #  branches: [ main ]
+  #  types:
+  #    - completed
 
 jobs:
   file-bookdown-pr:


### PR DESCRIPTION
This was on for testing purposes, but for templating purposes, it should be turned off and the getting_started.md doc describes how to turn it back on. 