### PR TITLE
render-bookdown.yml: Add push to main

### DIFF
--- a/.github/workflows/render-bookdown.yml
+++ b/.github/workflows/render-bookdown.yml
@@ -72,7 +72,8 @@ jobs:
           git config --local user.name "GitHub Actions"
           git add -A
           git commit -m 'Render bookdown' || echo "No changes to commit"
-
+          git push origin main || echo "No changes to push"
+          
       # Refresh google slide code images
       - name: Run google slide refresh script
         env:

--- a/.github/workflows/render-bookdown.yml
+++ b/.github/workflows/render-bookdown.yml
@@ -114,3 +114,4 @@ jobs:
           git config --local user.name "GitHub Actions"
           git add -A
           git commit -m 'Downloaded Google Slide Images' || echo "No changes to commit"
+          git push origin main || echo "No changes to push"


### PR DESCRIPTION
@cutsort identified commits weren't showing up when they should. Simple reason is there was no push command. Not sure when it got lost but adding it back in here. 