### PR TITLE
Add Rmds copying line to transfer-rendered-files.yml github action

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -4,7 +4,7 @@
 
 # Adapted for this jhudsl repository by Candace Savonen Apr 2021
 
-name: Copy docs/* folder from Bookdown to Leanpub repo
+name: Copy files from Bookdown to Leanpub repo
 # Copy rendered notebooks to Leanpub repo
 
 # This workflow will run when there are changes to docs/ files in THIS repo
@@ -45,7 +45,9 @@ jobs:
           # Copy over any .bib files too!
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/book.bib
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/packages.bib
-
+          
+          # Also need .Rmd files for leanbuild (at least first time... then might need to manually update iframes etc)
+          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/*.Rmd
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3
         id: cpr


### PR DESCRIPTION
# Summary 

Based on [this commit](https://github.com/jhudsl/ITCR_Cancer_Research_Leadership/commit/79158f87ed6698008921552116a0f9f72636032f) that included changes @carriewright11 made on a different repository; I'm copying those changes to the github actions file here. 

This makes it so by default the Rmd files will also be copied to a repository's Leanpub repo (when it is set up). 

Closes https://github.com/jhudsl/DaSL_Course_Template_Leanpub/issues/16