### PR TITLE
Clean up some of the files copied to Leanpub Repo

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -37,17 +37,26 @@ jobs:
           sudo apt-get install subversion
 
           # remove old docs/ files and folder
-          rm -r docs
+          rm -r manuscript
 
-          # Copy over files in docs
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/docs
+          # make manuscript directory
+          mkdir manuscript
 
           # Copy over any .bib files too!
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/book.bib
           svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/packages.bib
-          
-          # Also need .Rmd files for leanbuild (at least first time... then might need to manually update iframes etc)
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/*.Rmd
+
+          # Get list of Rmds needing to copy
+          rmd_list=$(find . -name '*.Rmd'  | grep '.Rmd')
+
+          for path in $rmd_list
+          do
+            # test that the path is to an Rmd file, error if not
+            [[ $path != *.Rmd ]] && echo "'$path' is not an .Rmd file." && exit 1
+            echo $path
+            svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/manuscript/${path}
+          done
+
       - name: Create PR with rendered docs files
         uses: peter-evans/create-pull-request@v3
         id: cpr

--- a/03-test_cases.Rmd
+++ b/03-test_cases.Rmd
@@ -5,7 +5,7 @@ leanbuild::set_knitr_image_path()
 
 # Uses cases for Bookdown to Leanpub
 
-Including a figure from the resources.  This shouldn't be an issue in the future 
+Including a figure from the resources.  This shouldn't be an issue in the future
 ```{r, out.width="100%", fig.cap = "caption for first figure, we need multiple so make sure it works"}
 knitr::include_graphics("resources/images/itcr_training_network.png")
 ```
@@ -38,7 +38,7 @@ knitr::include_graphics("https://upload.wikimedia.org/wikipedia/commons/e/e9/Fel
 ```
 
 
-Including a figure from the resources.  This shouldn't be an issue in the future 
+Including a figure from the resources.  This shouldn't be an issue in the future
 ```{r, fig.cap="url cap"}
 knitr::include_url("http://www.youtube.com/embed/9bZkp7q19f0?rel=0")
 ```
@@ -66,10 +66,6 @@ leanbuild::include_slide("https://docs.google.com/presentation/d/12DPZgPteQBwgal
 
 
 
-
 ```{r, eval = FALSE}
 knitr::include_url("https://docs.google.com/presentation/d/1cd434bkLer_CJ04GzpsZwzeEA9gjc5Ho6QimiHPbyEg/export/png?id=1cd434bkLer_CJ04GzpsZwzeEA9gjc5Ho6QimiHPbyEg&pageid=p")
 ```
-
-
-


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

Parallel change to https://github.com/jhudsl/ITCR_Documentation_and_Usability/pull/48

#### What changes are being implemented in this Pull Request?
Testing a change in github actions to clean out some unneeded files and only copy over the Rmds. 


#### What was your approach?
Alter some of the bash steps that copy over the files to only copy over the Rmds and not the docs folder (I don't think we need the docs folder for publishing to leanpub). We can do all the conversion for leanpub readiness in that repo and clean this repo up some. 

I think this will make the process a bit easier to follow and easier to maintain hopefully. 