### PR TITLE
Updating Pandoc in the docker image

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -11,7 +11,7 @@ name: Test build of Dockerfile
 on:
   pull_request:
     branches: [ main ]
-    paths: [ docker/Dockerfile ]
+    paths: [ docker/Dockerfile, docker/github_package_list.tsv ]
   workflow_dispatch:
     inputs:
       dockerhubpush:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,31 +12,19 @@ RUN apt-get install -y --no-install-recommends \
     libxt6 \
     libpoppler-cpp-dev
 
-
-### Install conda
-ENV PATH="/root/miniconda3/bin:${PATH}"
-ARG PATH="/root/miniconda3/bin:${PATH}"
-ENV PATH="/usr/lib/rstudio-server/bin:${PATH}"
-ARG PATH="/usr/lib/rstudio-server/bin:${PATH}"
-RUN apt-get update
-
-RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
-
-RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh
-RUN conda --version
-
 # Remove old symlinks to old pandoc
 RUN unlink /usr/lib/rstudio-server/bin/pandoc/pandoc
 
-# Install pandoc and pandoc-citeproc
-RUN conda install -c conda-forge pandoc
+# Uninstall old version of pandoc
+RUN sudo apt-get purge pandoc pandoc-citeproc pandoc-data \
+  && sudo apt-get autoremove --purge
+
+# Install pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb \
+  && sudo apt-get install ./pandoc-2.9.2.1-1-amd64.deb
 
 # Create new symlinks
-RUN ln -s /root/miniconda3/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/pandoc
+RUN ln -s /usr/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/pandoc
 
 # Add curl, bzip2
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get install -y --no-install-recommends \
 ### Install conda
 ENV PATH="/root/miniconda3/bin:${PATH}"
 ARG PATH="/root/miniconda3/bin:${PATH}"
+ENV PATH="/usr/lib/rstudio-server/bin:${PATH}"
+ARG PATH="/usr/lib/rstudio-server/bin:${PATH}"
 RUN apt-get update
 
 RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
@@ -34,7 +36,7 @@ RUN unlink /usr/lib/rstudio-server/bin/pandoc/pandoc
 RUN conda install -c conda-forge pandoc
 
 # Create new symlinks
-# RUN ln -s /root/miniconda3/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/
+RUN ln -s /root/miniconda3/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/pandoc
 
 # Add curl, bzip2
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,47 +10,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils dialo
 # These packages are dependencies
 RUN apt-get install -y --no-install-recommends \
     libxt6 \
-    libpoppler-cpp-dev \
-    cabal-install \
-    imagemagick \
-    librsvg2-bin \
-    librsvg2-common \
-    zlib1g \
-    zlib1g-dev
+    libpoppler-cpp-dev
+
+
+### Install conda
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+RUN apt-get update
+
+RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+
+RUN wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+RUN conda --version
+
+# Install pandoc
+RUN conda install -c conda-forge pandoc
 
 # Add curl, bzip2 and pandoc
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     bzip2 \
     curl
-
-RUN echo "Initial update." &&\
-    apt-get update &&\
-# install tzdata, which we will need down the line
-    apt-get install -f -y --no-install-recommends tzdata &&\
-    echo "Now installing cabal, imagemagick, and other tools." &&\
-# We install cabal, a Haskell package manager, because we want the newest
-# pandoc and filters which we can only get from there.
-# We also install zlib1g, as we will need it later on.
-# We install librsvg2 in order to make svg -> pdf conversation possible.
-# imagemagick may be needed by the latex-formulae-pandoc filter
-    apt-get install -f -y --no-install-recommends \
-      cabal-install \
-      imagemagick \
-      librsvg2-bin \
-      librsvg2-common \
-      zlib1g \
-      zlib1g-dev &&\
-# fix the access rights for imagemagick
-  echo "Fixing access rights for imagemagick." &&\
-  sed -i -e 's/rights="none"/rights="read|write"/g' /etc/ImageMagick-6/policy.xml &&\
-  sed -i -e 's/<\/policymap>/<policy domain="module" rights="read|write" pattern="{PS,PDF,XPS}" \/>\n<\/policymap>/g' /etc/ImageMagick-6/policy.xml &&\
-# print the versions of cabal and ghc
-    cabal --version &&\
-    ghc --version &&\
-# get the newest list of packages
-    cabal update &&\
-    cabal install pandoc &&\
-    cabal install pandoc-citeproc
 
 # Install pip3 and installation tools
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,13 @@ RUN apt-get install -y --no-install-recommends \
     libxt6 \
     libpoppler-cpp-dev
 
-# Add curl, bzip2
+# Add curl, bzip2 and pandoc
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     bzip2 \
-    curl
+    curl 
+
+RUN wget https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb
+RUN apt-get install ./pandoc-2.9.2.1-1-amd64.deb
 
 # Install pip3 and installation tools
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,15 +10,47 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils dialo
 # These packages are dependencies
 RUN apt-get install -y --no-install-recommends \
     libxt6 \
-    libpoppler-cpp-dev
+    libpoppler-cpp-dev \
+    cabal-install \
+    imagemagick \
+    librsvg2-bin \
+    librsvg2-common \
+    zlib1g \
+    zlib1g-dev
 
 # Add curl, bzip2 and pandoc
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     bzip2 \
-    curl 
+    curl
 
-RUN wget https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb
-RUN apt-get install ./pandoc-2.9.2.1-1-amd64.deb
+RUN echo "Initial update." &&\
+    apt-get update &&\
+# install tzdata, which we will need down the line
+    apt-get install -f -y --no-install-recommends tzdata &&\
+    echo "Now installing cabal, imagemagick, and other tools." &&\
+# We install cabal, a Haskell package manager, because we want the newest
+# pandoc and filters which we can only get from there.
+# We also install zlib1g, as we will need it later on.
+# We install librsvg2 in order to make svg -> pdf conversation possible.
+# imagemagick may be needed by the latex-formulae-pandoc filter
+    apt-get install -f -y --no-install-recommends \
+      cabal-install \
+      imagemagick \
+      librsvg2-bin \
+      librsvg2-common \
+      zlib1g \
+      zlib1g-dev &&\
+# fix the access rights for imagemagick
+  echo "Fixing access rights for imagemagick." &&\
+  sed -i -e 's/rights="none"/rights="read|write"/g' /etc/ImageMagick-6/policy.xml &&\
+  sed -i -e 's/<\/policymap>/<policy domain="module" rights="read|write" pattern="{PS,PDF,XPS}" \/>\n<\/policymap>/g' /etc/ImageMagick-6/policy.xml &&\
+# print the versions of cabal and ghc
+    cabal --version &&\
+    ghc --version &&\
+# get the newest list of packages
+    cabal update &&\
+    cabal install pandoc &&\
+    cabal install pandoc-citeproc
 
 # Install pip3 and installation tools
 RUN apt-get -y --no-install-recommends install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,9 @@ RUN Rscript -e  "install.packages( \
 COPY git_token.txt .
 COPY github_package_list.tsv .
 
+# Didactr needs this dependency:
+RUN Rscript -e  "devtools::install_version('lifecycle', version = '1.0.0', repos = 'http://cran.us.r-project.org')"
+
 # Install packages from github
 RUN Rscript install_github.R \
   --packages github_package_list.tsv \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,8 @@ RUN sudo apt-get purge pandoc pandoc-citeproc pandoc-data \
   && sudo apt-get autoremove --purge
 
 # Install pandoc
-RUN wget https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb \
-  && sudo apt-get install ./pandoc-2.9.2.1-1-amd64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/2.14.1/pandoc-2.14.1-1-amd64.deb \
+  && sudo apt-get install ./pandoc-2.14.1-1-amd64.deb
 
 # Create new symlinks
 RUN ln -s /usr/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/pandoc
@@ -50,10 +50,14 @@ RUN Rscript -e  "install.packages( \
       'spelling', \
       'styler'))"
 
-# Copy over git token
+# Copy over git token and package list
 COPY git_token.txt .
+COPY github_package_list.tsv .
 
 # Install packages from github
-RUN Rscript --vanilla install_github.R \
-  --packages "jhudsl/didactr, jhudsl/leanbuild" \
+RUN Rscript install_github.R \
+  --packages github_package_list.tsv \
   --token git_token.txt
+
+# Set final workdir for commands
+WORKDIR /home/rstudio

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,10 +27,16 @@ RUN wget \
     && rm -f Miniconda3-latest-Linux-x86_64.sh
 RUN conda --version
 
-# Install pandoc
+# Remove old symlinks to old pandoc
+RUN unlink /usr/lib/rstudio-server/bin/pandoc/pandoc
+
+# Install pandoc and pandoc-citeproc
 RUN conda install -c conda-forge pandoc
 
-# Add curl, bzip2 and pandoc
+# Create new symlinks
+# RUN ln -s /root/miniconda3/bin/pandoc /usr/lib/rstudio-server/bin/pandoc/
+
+# Add curl, bzip2
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
     bzip2 \
     curl
@@ -61,6 +67,3 @@ COPY git_token.txt .
 RUN Rscript --vanilla install_github.R \
   --packages "jhudsl/didactr, jhudsl/leanbuild" \
   --token git_token.txt
-
-# Set final workdir for commands
-WORKDIR /home/rstudio

--- a/docker/github_package_list.tsv
+++ b/docker/github_package_list.tsv
@@ -2,4 +2,5 @@ rstudio/rmarkdown	02d3c2512686fda9c14c2a0e300aa02525f16ca5
 yihui/xfun	dd87cfc37743f93c3f6a9f9c99b6f5335895fccb
 yihui/knitr	a1052d12e0ff8f4ead365b4c85ef5835faa1c492
 jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
+r-lib/rlang	f0c9be5c5806b4e4b120b7516f286fef3c66bda5
 jhudsl/leanbuild	HEAD

--- a/docker/github_package_list.tsv
+++ b/docker/github_package_list.tsv
@@ -1,0 +1,4 @@
+rstudio/rmarkdown	02d3c2512686fda9c14c2a0e300aa02525f16ca5
+yihui/knitr	a1052d12e0ff8f4ead365b4c85ef5835faa1c492
+jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
+jhudsl/leanbuild	HEAD

--- a/docker/github_package_list.tsv
+++ b/docker/github_package_list.tsv
@@ -1,6 +1,7 @@
 rstudio/rmarkdown	02d3c2512686fda9c14c2a0e300aa02525f16ca5
 yihui/xfun	dd87cfc37743f93c3f6a9f9c99b6f5335895fccb
 yihui/knitr	a1052d12e0ff8f4ead365b4c85ef5835faa1c492
-jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
 r-lib/rlang	f0c9be5c5806b4e4b120b7516f286fef3c66bda5
+jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
 jhudsl/leanbuild	HEAD
+tidyverse/rvest	4fe39fb5089512d77b6a9cc026e5c895258ff6ce

--- a/docker/github_package_list.tsv
+++ b/docker/github_package_list.tsv
@@ -1,4 +1,5 @@
 rstudio/rmarkdown	02d3c2512686fda9c14c2a0e300aa02525f16ca5
+yihui/xfun	dd87cfc37743f93c3f6a9f9c99b6f5335895fccb
 yihui/knitr	a1052d12e0ff8f4ead365b4c85ef5835faa1c492
 jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
 jhudsl/leanbuild	HEAD

--- a/packages.bib
+++ b/packages.bib
@@ -10,16 +10,16 @@
 @Manual{R-bookdown,
   title = {bookdown: Authoring Books and Technical Documents with R Markdown},
   author = {Yihui Xie},
-  year = {2021},
-  note = {R package version 0.23},
-  url = {https://CRAN.R-project.org/package=bookdown},
+  year = {2020},
+  note = {R package version 0.20},
+  url = {https://github.com/rstudio/bookdown},
 }
 
 @Manual{R-knitr,
   title = {knitr: A General-Purpose Package for Dynamic Report Generation in R},
   author = {Yihui Xie},
-  year = {2021},
-  note = {R package version 1.33},
+  year = {2020},
+  note = {R package version 1.30},
   url = {https://yihui.org/knitr/},
 }
 
@@ -27,8 +27,8 @@
   title = {rmarkdown: Dynamic Documents for R},
   author = {JJ Allaire and Yihui Xie and Jonathan McPherson and Javier Luraschi and Kevin Ushey and Aron Atkins and Hadley Wickham and Joe Cheng and Winston Chang and Richard Iannone},
   year = {2021},
-  note = {R package version 2.10},
-  url = {https://CRAN.R-project.org/package=rmarkdown},
+  note = {https://github.com/rstudio/rmarkdown,
+https://pkgs.rstudio.com/rmarkdown/},
 }
 
 @Book{bookdown2016,
@@ -38,7 +38,7 @@
   address = {Boca Raton, Florida},
   year = {2016},
   note = {ISBN 978-1138700109},
-  url = {https://bookdown.org/yihui/bookdown},
+  url = {https://github.com/rstudio/bookdown},
 }
 
 @Book{knitr2015,


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I've updated pandoc in the docker image to be 2.14.1 which does allow leanbuild::bookdown_to_leanpub() to run properly (as I tested on my local RStudio). 

However, this isn't the end of it, because I'm still unable to get the RStudio of the resulting docker image to link to this newer version of pandoc. I've been trying to use the various `find_pandoc()` functions https://bookdown.org/yihui/rmarkdown-cookbook/install-pandoc.html to set this, but it can never find it. 

I know the installation location of pandoc is `/root/miniconda3/bin/pandoc` but I don't know how to tell RStudio to use it. Apparently it doesn't think it has permissions to that file. 

When I run `--pandoc version` using `docker exec -it <container_id> bash` it correctly tells me that I have the updated pandoc version. Just can't get RStudio to use it. 

#### What GitHub issue does your pull request address?
It's toward working on https://github.com/jhudsl/leanbuild/issues/5 but it is not completely resolved. 😞 

