### PR TITLE
Force new copies to overwrite old ones in Leanpub transfer

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -43,10 +43,10 @@ jobs:
           fi
 
           # Copy over book.bib file
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/book.bib
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/book.bib
 
           # Copy over _bookdown.yml
-          svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml
 
           # Get list of Rmds needing to copy
           rmd_list=$(find . -name '*.Rmd'  | grep '.Rmd')
@@ -56,7 +56,7 @@ jobs:
             # test that the path is to an Rmd file, error if not
             [[ $path != *.Rmd ]] && echo "'$path' is not an .Rmd file." && exit 1
             echo $path
-            svn export https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/manuscript/${path}
+            svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/manuscript/${path}
           done
 
       - name: Create PR with rendered docs files


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
We want the newer copies of files from here to overwrite the old ones in a Pull Request over in _Leanpub repo. 


#### What was your approach?
To do this need to use `--force` option with `svn export` to try to fix this error: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/actions/runs/1158565328


#### What GitHub issue does your pull request address?
https://github.com/jhudsl/DaSL_Course_Template_Bookdown/actions/runs/1158565328
