### PR TITLE
Add line to transfer images by gha to Leanpub repo

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -49,6 +49,9 @@ jobs:
           # Copy over _bookdown.yml
           svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml
 
+          # Copy over images folder
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/images resources/images
+
           # Get list of Rmds needing to copy
           Rscript --vanilla scripts/get_rmd_filenames.R
 


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

Just adding one line to make sure the resources/images folder also makes it over to the Leanpub repo

