### PR TITLE
Update `testthat` package in docker image

### DIFF
--- a/docker/github_package_list.tsv
+++ b/docker/github_package_list.tsv
@@ -5,3 +5,4 @@ r-lib/rlang	f0c9be5c5806b4e4b120b7516f286fef3c66bda5
 jhudsl/didactr	cde4598c10f2b5e2e31b47fe94ca1b02db420e10
 jhudsl/leanbuild	HEAD
 tidyverse/rvest	4fe39fb5089512d77b6a9cc026e5c895258ff6ce
+R-lib/testthat	e99155af85261e065192feb946dcfa6679cffae4


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

If this works, it should close #163 

#### What was your approach?
I added a specific version of `testthat` to install that has the `testthat_print()` function 
