### PR TITLE
Provide way for course writers to file issues about the template

### DIFF
--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,23 @@
+name: Template Problem Report
+description: File an issue about problems with the template/template documentation
+title: "[Problem]: "
+labels: ["problem", "triage"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue!
+        The more details you are able to provide, the better we will be able to help!
+  - type: markdown
+    attributes:
+      label: problem
+      value: What is not working with the template? Or what is unclear in the documentation? The more context you can provide around the problem, the better.
+  - type: markdown
+    attributes:
+      label: location
+      value: What course repository are you seeing this problem on? (Provide a link please).
+  - type: markdown
+    attributes:
+      value: Please post a link to any failed Github actions (if relevant).

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -55,7 +55,8 @@ jobs:
           rm -rf \
             .github/workflows/downstream-mechanics-updates.yml \
             .github/sync.yml \
-            .github/workflows/starting-course.yml
+            .github/workflows/starting-course.yml \
+            .github/ISSUE_TEMPLATES/config.yml
 
       # Commit modified files
       - name: Commit deleted files


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Adding some direction about how to file issues with the template. 

I'm trying out the config.yml strategy with github issues: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

Now sure what this will look like.

I added the relevant files to the starting_course.yml gha so they will be deleted when the template is used to make a new course. 

I'll also add instructions on the getting_started.md that steers people to this issue filer. 
