### PR TITLE
Add guidance on sync PRs via a comment

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -15,6 +15,8 @@ group:
       dest: .github/workflows/style-and-sp-check.yml
     - source: .github/workflows/url-checker.yml
       dest: .github/workflows/url-checker.yml
+    - source: .github/workflows/release-notes.yml
+      dest: .github/workflows/release-notes.yml
     - source: scripts/
       dest: scripts/
     - source: docker/

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches: [ main ]
     paths: [ docker/Dockerfile, docker/github_package_list.tsv ]
+    branches-ignore: [ repo-sync/DaSL_Course_Template_Leanpub/default ]
   workflow_dispatch:
     inputs:
       dockerhubpush:

--- a/.github/workflows/downstream-mechanics-updates.yml
+++ b/.github/workflows/downstream-mechanics-updates.yml
@@ -3,8 +3,6 @@
 name: Sync Files
 on:
   workflow_dispatch:
-    inputs:
-    release_notes:
 
 jobs:
   sync:

--- a/.github/workflows/downstream-mechanics-updates.yml
+++ b/.github/workflows/downstream-mechanics-updates.yml
@@ -3,6 +3,8 @@
 name: Sync Files
 on:
   workflow_dispatch:
+    inputs:
+    release_notes:
 
 jobs:
   sync:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,15 +6,26 @@ on:
       - repo-sync/DaSL_Course_Template_Leanpub/default
 
 jobs:
-  test:
+  pr-comment:
     runs-on: ubuntu-latest
     steps:
       - uses: mshick/add-pr-comment@v1
         with:
           message: |
-            **Hello**
-            🌏
-            !
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+            **Please carefully review these changes and decide which are useful for your course.**
+            See the release notes: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Release-Notes
+
+            - If you don't want the changes from a particular file, you can always [revert that particular commit](https://git-scm.com/docs/git-revert) before merging the sync PR.
+            If you will not want any updates on this file in the future, you may want to remove a file from being synced in your repo [by reconfiguring the sync file](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/.github/sync.yml).
+
+            - If you want only some changes, but they are not on a whole file basis, you could check out the branch and make manual edits.
+
+            To checkout the branch, navigate to your own repository you should be able to run:
+            ```
+            git checkout repo-sync/DaSL_Course_Template_Bookdown/default
+            ```
+            - If you don't want any of the changes you can close the PR entirely.
+            You may want to unenroll your repository from the [sync github actions by deleting your repo name from this file](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/.github/sync.yml) if this will continue to be the case.
+          repo-token: ${{ secrets.GH_PAT }}
           repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
           allow-repeats: false # This is the default

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,20 @@
+# Candace Savonen Aug 2021
+
+on:
+  pull_request:
+    branches:
+      - repo-sync/DaSL_Course_Template_Leanpub/default
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            **Hello**
+            🌏
+            !
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+          allow-repeats: false # This is the default


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Add a sync PR message that gives people guidance on what to do with the sync PRs. Like look at the release notes and how to sort through the changes

This also closes #185 by ignoring any `repo-sync/DaSL_Course_Template_Leanpub/default` changes https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions

### Approach: 

Each repo made from this template will have an automatic github action that adds a comment to a PR that's made with the `repo-sync/DaSL_Course_Template_Leanpub/default` branch (which is what the sync PRs are made on). 