### PR TITLE
Add git repo checker step in transfer-rendered-files.yml

### DIFF
--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -37,6 +37,7 @@ jobs:
           results=$(Rscript "scripts/spell-check.R")
           echo "::set-output name=sp_chk_results::$results"
           cat spell_check_results.tsv
+          
       - name: Archive spelling errors
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -30,7 +30,7 @@ jobs:
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
 
-          results=$(Rscript --vanilla scripts/git_repo_check.R ${GITHUB_REPOSITORY})
+          results=$(Rscript --vanilla scripts/git_repo_check.R $GITHUB_REPOSITORY)
           echo $results
           # echo "::set-output name=git_results::$results"
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -4,7 +4,7 @@
 
 # Adapted for this jhudsl repository by Candace Savonen Apr 2021
 
-name: Copy files from Bookdown to Leanpub repo
+name: Bookdown to Leanpub repo copy over
 # Copy rendered notebooks to Leanpub repo
 
 # This workflow will run when there are changes to docs/ files in THIS repo
@@ -39,7 +39,7 @@ jobs:
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R "$GITHUB_REPOSITORY")
           echo $LEANPUB_REPO exists: $results
-          # echo "::set-output name=git_results::$results"
+          echo "::set-output name=git_results::$results"
 
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Get files from Bookdown repo
-        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
+        if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -97,7 +97,7 @@ jobs:
           done < "$input"
 
       - name: Create PR with rendered docs files
-        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
+        if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
@@ -109,6 +109,7 @@ jobs:
           title: 'GHA: Automated transfer of leanbuild-needed files from Bookdown repository'
           body: |
             ### Description:
+             This PR was initiated by: $GITHUB_REF
              Copying over the leanbuild-needed files from Bookdown repository:
                - Rmds listed in the _bookdoown.yml
                - _bookdown.yml
@@ -122,7 +123,7 @@ jobs:
 
       # Write out PR info
       - name: Check outputs
-        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
+        if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -36,8 +36,6 @@ jobs:
           # Get repo check script
           svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
 
-          git_repo_check.R
-
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R "$GITHUB_REPOSITORY")
           echo $LEANPUB_REPO exists: $results

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
+          sudo apt-get install subversion
+          
           # What's the LEANPUB repository's name?
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
@@ -52,7 +54,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          sudo apt-get install subversion
           sudo apt install r-base
           sudo Rscript -e "install.packages('yaml')"
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
-        LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
+          LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
 
-        results=$(Rscript "scripts/git_repo_check.R $LEANPUB_REPO")
-        echo "::set-output name=git_repo_check::$results"
+          results=$(Rscript "scripts/git_repo_check.R $LEANPUB_REPO")
+          echo "::set-output name=git_repo_check::$results"
 
       - name: Quit if LEANPUB_REPO doesn't exist
         if: ${{ steps.git_repo_check.outputs.results == TRUE }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
 
-          results=$(Rscript --vanilla scripts/git_repo_check.R "$LEANPUB_REPO")
+          results=$(Rscript --vanilla scripts/git_repo_check.R $LEANPUB_REPO)
           echo "::set-output name=git_repo_check::$results"
 
       - name: Checkout code from Leanpub repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
+
           results=$(Rscript --vanilla scripts/git_repo_check.R ${GITHUB_REPOSITORY})
           echo $results
           # echo "::set-output name=git_results::$results"
@@ -37,7 +38,7 @@ jobs:
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v2
         with:
-          repository: ${{ steps.get_repo_name.outputs.LEANPUB_REPO }}
+          repository: ${{ steps.git_repo_check.outputs.LEANPUB_REPO }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Get files from Bookdown repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -28,7 +28,7 @@ jobs:
         id: git_repo_check
         run: |
           results=$(Rscript --vanilla scripts/git_repo_check.R ${GITHUB_REPOSITORY})
-          echo "::set-output name=git_repo_check::$results"
+          echo "::set-output name=results::$results"
 
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,12 +27,16 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
+          # What's the LEANPUB repository's name?
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
-          echo $GITHUB_REPOSITORY
 
+          # Get repo check script
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R
+
+          # Run repo check script
           results=$(Rscript --vanilla scripts/git_repo_check.R "$GITHUB_REPOSITORY")
-          echo $results
+          echo $LEANPUB_REPO exists: $results
           # echo "::set-output name=git_results::$results"
 
       - name: Checkout code from Leanpub repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -29,8 +29,9 @@ jobs:
         run: |
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
+          echo $GITHUB_REPOSITORY
 
-          results=$(Rscript --vanilla scripts/git_repo_check.R $GITHUB_REPOSITORY)
+          results=$(Rscript --vanilla scripts/git_repo_check.R "$GITHUB_REPOSITORY")
           echo $results
           # echo "::set-output name=git_results::$results"
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -24,36 +24,26 @@ jobs:
 
     # Get repository name by dropping Bookdown if it exists but always append _Leanpub
     steps:
-      - name: Get repository name
-        id: get_repo_name
-        shell: bash
+      - name: Run git repo check
+        id: git_repo_check
         run: |
-          LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
-          echo $LEANPUB_REPO
+        LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
 
-      - name: Set up test for if LEANPUB REPO EXISTS
-        run: |
-          LEANPUB_REPO_EXISTS=$(git ls-remote https://github.com/$LEANPUB_REPO > /dev/null 2>&1)
-          FALSE=false
-          if [ "$?" -ne 0 ]; then
-            LEANPUB_REPO_EXISTS=false
-            echo "'$LEANPUB_REPO' does not exist in GitHub; skipping transfer"
-          fi
+        results=$(Rscript "scripts/git_repo_check.R $LEANPUB_REPO")
+        echo "::set-output name=git_repo_check::$results"
 
       - name: Quit if LEANPUB_REPO doesn't exist
-        if: ${{ steps.spell_check_run.outputs.LEANPUB_REPO_EXISTS == steps.spell_check_run.outputs.FALSE }}
-        run:
-          set +e
-          exit 1
-          set -e
+        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
 
       - name: Checkout code from Leanpub repo
+        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
         uses: actions/checkout@v2
         with:
           repository: ${{ steps.get_repo_name.outputs.LEANPUB_REPO }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Get files from Bookdown repo
+        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -102,6 +92,7 @@ jobs:
           done < "$input"
 
       - name: Create PR with rendered docs files
+        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
@@ -126,6 +117,7 @@ jobs:
 
       # Write out PR info
       - name: Check outputs
+        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -28,16 +28,18 @@ jobs:
         id: git_repo_check
         run: |
           sudo apt-get install subversion
-          
+
           # What's the LEANPUB repository's name?
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
           echo $LEANPUB_REPO
 
           # Get repo check script
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
+
+          git_repo_check.R
 
           # Run repo check script
-          results=$(Rscript --vanilla scripts/git_repo_check.R "$GITHUB_REPOSITORY")
+          results=$(Rscript --vanilla git_repo_check.R "$GITHUB_REPOSITORY")
           echo $LEANPUB_REPO exists: $results
           # echo "::set-output name=git_results::$results"
 

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -32,9 +32,6 @@ jobs:
           results=$(Rscript "scripts/git_repo_check.R $LEANPUB_REPO")
           echo "::set-output name=git_repo_check::$results"
 
-      - name: Quit if LEANPUB_REPO doesn't exist
-        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
-
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.results == TRUE }}
         uses: actions/checkout@v2

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
-          LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
+          LEANPUB_REPO=$(${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
 
           results=$(Rscript --vanilla scripts/git_repo_check.R $LEANPUB_REPO)
           echo "::set-output name=git_repo_check::$results"

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
+          LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
+          echo $LEANPUB_REPO
           results=$(Rscript --vanilla scripts/git_repo_check.R ${GITHUB_REPOSITORY})
-          echo "::set-output name=results::$results"
+          echo $results
+          # echo "::set-output name=git_results::$results"
 
       - name: Checkout code from Leanpub repo
-        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
+        if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v2
         with:
           repository: ${{ steps.get_repo_name.outputs.LEANPUB_REPO }}

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -33,14 +33,14 @@ jobs:
           echo "::set-output name=git_repo_check::$results"
 
       - name: Checkout code from Leanpub repo
-        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
+        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
         uses: actions/checkout@v2
         with:
           repository: ${{ steps.get_repo_name.outputs.LEANPUB_REPO }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Get files from Bookdown repo
-        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
+        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -89,7 +89,7 @@ jobs:
           done < "$input"
 
       - name: Create PR with rendered docs files
-        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
+        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
@@ -114,7 +114,7 @@ jobs:
 
       # Write out PR info
       - name: Check outputs
-        if: ${{ steps.git_repo_check.outputs.results == TRUE }}
+        if: ${{ steps.git_repo_check.outputs.results == 'TRUE' }}
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -39,13 +39,15 @@ jobs:
           # Run repo check script
           results=$(Rscript --vanilla git_repo_check.R "$GITHUB_REPOSITORY")
           echo $LEANPUB_REPO exists: $results
+
           echo "::set-output name=git_results::$results"
+          echo "::set-output name=leanpub_repo::$LEANPUB_REPO"
 
       - name: Checkout code from Leanpub repo
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v2
         with:
-          repository: ${{ steps.git_repo_check.outputs.LEANPUB_REPO }}
+          repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Get files from Bookdown repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Run git repo check
         id: git_repo_check
         run: |
-          LEANPUB_REPO=$(${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
-
-          results=$(Rscript --vanilla scripts/git_repo_check.R $LEANPUB_REPO)
+          results=$(Rscript --vanilla scripts/git_repo_check.R ${GITHUB_REPOSITORY})
           echo "::set-output name=git_repo_check::$results"
 
       - name: Checkout code from Leanpub repo

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')
 
-          results=$(Rscript "scripts/git_repo_check.R $LEANPUB_REPO")
+          results=$(Rscript --vanilla scripts/git_repo_check.R "$LEANPUB_REPO")
           echo "::set-output name=git_repo_check::$results"
 
       - name: Checkout code from Leanpub repo

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -4,6 +4,10 @@
 
 repo <- commandArgs(trailingOnly = TRUE)
 
+if (!is.character(repo)) {
+  repo <- as.character(repo)
+}
+
 check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   # Given a repository name, check with git ls-remote whether the repository 
   # exists and return a TRUE/FALSE

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -1,0 +1,52 @@
+#!/usr/bin/env Rscript
+
+# Written by Candace Savonen Sept 2021
+
+repo <- commandArgs(trailingOnly = TRUE)
+repo <- "jhudsl/DaSL_Course_Template_Bookdown"
+
+check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
+  # Given a repository name, check with git ls-remote whether the repository 
+  # exists and return a TRUE/FALSE
+  
+  # Inputs: 
+  # repo: the name of the repository, e.g. jhudsl/DaSL_Course_Template_Bookdown
+  # silent: TRUE/FALSE of whether the warning from the git ls-remote command 
+  #         should be echoed back if it does fail.
+  # return_repo: TRUE/FALSE of whether or not the output from git ls-remote 
+  #              should be saved to a file (if the repo exists)
+  
+  # Returns: 
+  # A TRUE/FALSE whether or not the repository exists. 
+  # Optionally the output from git ls-remote if return_repo = TRUE. 
+  
+  message(paste("Checking for remote git repository:", repo))
+
+  # If silent = TRUE don't print out the warning message from the 'try'
+  report <- ifelse(silent, suppressWarnings, message)
+
+  # Try to git ls-remote the repo given
+  test_repo <- report(
+    try(system(paste0("git ls-remote https://github.com/", repo),
+              intern = TRUE, ignore.stderr = TRUE))
+    )
+
+  # If 128 is returned as a status attribute it means it failed
+  exists <- ifelse(is.null(attr(test_repo, "status")), TRUE, FALSE)
+                 
+  if (return_repo && exists) {
+    # Make file name
+    output_file <- paste0("git_ls_remote_", gsub("/", "_", repo))
+    
+    # Tell the user the file was saved
+    message(paste("Saving output from git ls-remote to file:", output_file))
+    
+    # Write to file
+    writeLines(exists, file.path(output_file))
+  }
+
+  return(exists)
+}
+
+# Print out the result
+write(check_git_repo(repo), stdout())

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -3,7 +3,7 @@
 # Written by Candace Savonen Sept 2021
 
 repo <- commandArgs(trailingOnly = TRUE)
-repo <- "jhudsl/DaSL_Course_Template_Bookdown"
+
 check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   # Given a repository name, check with git ls-remote whether the repository 
   # exists and return a TRUE/FALSE

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -2,8 +2,7 @@
 
 # Written by Candace Savonen Sept 2021
 
-repo <- commandArgs(trailingOnly = TRUE)
-repo <- "jhudsl/DaSL_Course_Template_Bookdown"
+repo <- commandArgs()
 
 check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   # Given a repository name, check with git ls-remote whether the repository 

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -3,7 +3,7 @@
 # Written by Candace Savonen Sept 2021
 
 repo <- commandArgs(trailingOnly = TRUE)
-
+repo <- "jhudsl/DaSL_Course_Template_Bookdown"
 check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   # Given a repository name, check with git ls-remote whether the repository 
   # exists and return a TRUE/FALSE
@@ -46,6 +46,11 @@ check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
 
   return(exists)
 }
+
+
+# Change repo name to its Leanpub equivalent: 
+repo <- gsub("Bookdown", "", repo)
+repo <- paste0(repo, "Leanpub")
 
 # Print out the result
 write(check_git_repo(repo), stdout())

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -2,7 +2,7 @@
 
 # Written by Candace Savonen Sept 2021
 
-repo <- commandArgs()
+repo <- commandArgs(trailingOnly = TRUE)
 
 check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   # Given a repository name, check with git ls-remote whether the repository 


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I wanted a way to have the transfer-rendered-files.yml to run only if the companion Leanpub repository exists. BUT I don't want it to look like it fails if it doesn't exist because that's okay to skip it if it doesn't exist. 

So I needed to first write a thing that would give me a TRUE/FALSE does this repo exist, but bash doesn't have a great try/catch system so I had to make an Rscript and function to do this. 

#### What GitHub issue does your pull request address?

Related to the errors happening on github actions: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/actions/runs/1261933208

