### PR TITLE
Add GH PAT handling to git-check-repo.R

### DIFF
--- a/.github/workflows/render-bookdown.yml
+++ b/.github/workflows/render-bookdown.yml
@@ -10,6 +10,7 @@ name: Build, Render, and Push
 # Controls when the action will run. Triggers the workflow on push
 # events only for the master branch
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -10,6 +10,7 @@ name: Style and spell check R markdowns
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 
@@ -37,7 +38,7 @@ jobs:
           results=$(Rscript "scripts/spell-check.R")
           echo "::set-output name=sp_chk_results::$results"
           cat spell_check_results.tsv
-          
+
       - name: Archive spelling errors
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -30,6 +30,7 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           sudo apt-get install subversion
+          sudo Rscript -e "install.packages('optparse')"
 
           # What's the LEANPUB repository's name?
           LEANPUB_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | awk '{print $1"_Leanpub"}')

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Run git repo check
         id: git_repo_check
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           sudo apt-get install subversion
 
@@ -37,7 +39,7 @@ jobs:
           svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
 
           # Run repo check script
-          results=$(Rscript --vanilla git_repo_check.R "$GITHUB_REPOSITORY")
+          results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
           echo $LEANPUB_REPO exists: $results
 
           echo "::set-output name=git_results::$results"
@@ -54,7 +56,7 @@ jobs:
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           sudo apt install r-base
           sudo Rscript -e "install.packages('yaml')"
@@ -111,8 +113,8 @@ jobs:
           title: 'GHA: Automated transfer of leanbuild-needed files from Bookdown repository'
           body: |
             ### Description:
-             This PR was initiated by: ${GITHUB_REF}
-             Copying over the leanbuild-needed files from Bookdown repository:
+             This PR was initiated by transfer-rendered.yml in the Bookdown repository.
+             It copies over the leanbuild-needed files from Bookdown repository:
                - Rmds listed in the _bookdoown.yml
                - _bookdown.yml
                - docs/*

--- a/.github/workflows/url-checker.yml
+++ b/.github/workflows/url-checker.yml
@@ -5,6 +5,7 @@ name: Check URLs
 
 # This will be run upon PRs to main
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
 

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -2,6 +2,12 @@
 
 # Written by Candace Savonen Sept 2021
 
+if (!("optparse" %in% installed.packages())){
+  install.packages("optparse")
+}
+
+library(optparse)
+
 option_list <- list(
   optparse::make_option(
     c("--repo"),

--- a/scripts/git_repo_check.R
+++ b/scripts/git_repo_check.R
@@ -2,48 +2,80 @@
 
 # Written by Candace Savonen Sept 2021
 
-repo <- commandArgs(trailingOnly = TRUE)
+option_list <- list(
+  optparse::make_option(
+    c("--repo"),
+    type = "character",
+    default = NULL,
+    help = "GitHub repository name, e.g. jhudsl/DaSL_Course_Template_Bookdown",
+  ),
+  optparse::make_option(
+    c("--git_pat"),
+    type = "character",
+    default = NULL,
+    help = "GitHub personal access token",
+  )
+)
+
+# Read the arguments passed
+opt_parser <- optparse::OptionParser(option_list = option_list)
+opt <- optparse::parse_args(opt_parser)
+
+repo <- opt$repo
+git_pat <- opt$git_pat
 
 if (!is.character(repo)) {
   repo <- as.character(repo)
 }
 
-check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
-  # Given a repository name, check with git ls-remote whether the repository 
+check_git_repo <- function(repo, git_pat = NULL, silent = TRUE, return_repo = FALSE) {
+  # Given a repository name, check with git ls-remote whether the repository
   # exists and return a TRUE/FALSE
-  
-  # Inputs: 
+
+  # Inputs:
   # repo: the name of the repository, e.g. jhudsl/DaSL_Course_Template_Bookdown
-  # silent: TRUE/FALSE of whether the warning from the git ls-remote command 
+  # git_pat: A personal access token from GitHub. Only necessary if the repository being 
+  #          checked is a private repository. 
+  # silent: TRUE/FALSE of whether the warning from the git ls-remote command
   #         should be echoed back if it does fail.
-  # return_repo: TRUE/FALSE of whether or not the output from git ls-remote 
+  # return_repo: TRUE/FALSE of whether or not the output from git ls-remote
   #              should be saved to a file (if the repo exists)
-  
-  # Returns: 
-  # A TRUE/FALSE whether or not the repository exists. 
-  # Optionally the output from git ls-remote if return_repo = TRUE. 
-  
+
+  # Returns:
+  # A TRUE/FALSE whether or not the repository exists.
+  # Optionally the output from git ls-remote if return_repo = TRUE.
+
   message(paste("Checking for remote git repository:", repo))
 
   # If silent = TRUE don't print out the warning message from the 'try'
   report <- ifelse(silent, suppressWarnings, message)
 
-  # Try to git ls-remote the repo given
-  test_repo <- report(
-    try(system(paste0("git ls-remote https://github.com/", repo),
-              intern = TRUE, ignore.stderr = TRUE))
+  if (!is.null(git_pat)) {
+    # If git_pat is supplied, use it
+    test_repo <- report(
+      try(system(paste0("git ls-remote https://", git_pat, "@github.com/", repo),
+        intern = TRUE, ignore.stderr = TRUE
+      ))
     )
+  } else {
 
+    # Try to git ls-remote the repo given
+    test_repo <- report(
+      try(system(paste0("git ls-remote https://github.com/", repo),
+        intern = TRUE, ignore.stderr = TRUE
+      ))
+    )
+  }
   # If 128 is returned as a status attribute it means it failed
   exists <- ifelse(is.null(attr(test_repo, "status")), TRUE, FALSE)
-                 
+
   if (return_repo && exists) {
     # Make file name
     output_file <- paste0("git_ls_remote_", gsub("/", "_", repo))
-    
+
     # Tell the user the file was saved
     message(paste("Saving output from git ls-remote to file:", output_file))
-    
+
     # Write to file
     writeLines(exists, file.path(output_file))
   }
@@ -51,10 +83,9 @@ check_git_repo <- function(repo, silent = TRUE, return_repo = FALSE) {
   return(exists)
 }
 
-
-# Change repo name to its Leanpub equivalent: 
+# Change repo name to its Leanpub equivalent:
 repo <- gsub("_Bookdown", "", repo)
 repo <- paste0(repo, "_Leanpub")
 
 # Print out the result
-write(check_git_repo(repo), stdout())
+write(check_git_repo(repo, git_pat = git_pat), stdout())


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

This should close: #235 

#### What was your approach?
- I added an argument that can take a github pat in git-check-repo.R 
- transfer-rendered.yml now passes a PAT to said argument in git-check-repo.R

This works locally and *should* work here and shouldn't require people to take any extra steps. :+1: 