### PR TITLE
Update sync.yml with impending repo name changes 

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -4,9 +4,9 @@
 group:
   # Repositories to recieve changes
   repos: |
-    jhudsl/ITCR_Documentation_and_Usability
-    jhudsl/ITCR_Cancer_Research_Leadership
-    jhudsl/ITCR_Data_Management
+    jhudsl/Documentation_and_Usability
+    jhudsl/Cancer_Research_Leadership
+    jhudsl/Data_Management
 #ADD NEW REPO HERE following the format above#
   files:
     - source: .github/workflows/docker-build-test.yml


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

We’re dropping the ITCR_ prefix from some course repositories. So sync.yml needs to be updated accordingly. We will see if any other changes are needed.