### PR TITLE
Add delay to deleting branch

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -10,6 +10,11 @@ jobs:
   build-all:
     runs-on: ubuntu-latest
     steps:
+      # This is because if a PR is closed before a render finishes it won't find it. 
+      - name: Sleep for 5 minutes
+        run: sleep 300s
+        shell: bash
+
       - name: Delete branch
         uses: dawidd6/action-delete-branch@v3
         with:

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -10,11 +10,12 @@ jobs:
   build-all:
     runs-on: ubuntu-latest
     steps:
-      # This is because if a PR is closed before a render finishes it won't find it. 
+      # This is because if a PR is closed before a render finishes it won't find it.
       - name: Sleep for 5 minutes
         run: sleep 300s
         shell: bash
 
+      # Delete the branch!
       - name: Delete branch
         uses: dawidd6/action-delete-branch@v3
         with:


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Delete preview github actions sometimes works and sometimes doesn't: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/actions/workflows/delete-preview.yml

I think the reason is that if a preview render is in the midst of processing and we close a PR it can't find the branch. 
To see if this is the case, I added a 5 minute delay to the deleting of the branch. That should give the preview render time to catch up. 

If this isn't the problem, then I will go back to the drawing board to figure out why it sometimes fails. 
