### PR TITLE
Add render-bookdown.yml to sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -9,6 +9,8 @@ group:
     jhudsl/Data_Management
 #ADD NEW REPO HERE following the format above#
   files:
+    - source: .github/workflows/render-bookdown.yml
+      dest: .github/workflows/render-bookdown.yml
     - source: .github/workflows/docker-build-test.yml
       dest: .github/workflows/docker-build-test.yml
     - source: .github/workflows/transfer-rendered-files.yml


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
There were changes I expected to see on my Docs and Usability course that didn't show up there. And I realized its because my changes to render-bookdown.yml did not get propagated to downstream repos. So I'm adding it now. 
Originally I didn't add it to sync.yml because the google slides stuff was needing to be personalized but that has since been retired and no longer needed because leanbuild takes care of google slide linking. 

