### PR TITLE
render-bookdown is self-triggering

### DIFF
--- a/.github/workflows/render-bookdown.yml
+++ b/.github/workflows/render-bookdown.yml
@@ -13,7 +13,10 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-
+    paths:
+      - '**.Rmd'
+      - docker/Dockerfile
+      - assets/*
 jobs:
   # This workflow contains a single job called "build-all"
   build-all:


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I forgot that not specifying the `path` option in the trigger would make `render-bookdown.yml` trigger itself to run. So instead I've restore the path argument but added `assets` this time. 
