### PR TITLE
Test v1.8.0 of BetaHuhn/repo-file-sync-action

### DIFF
--- a/.github/workflows/downstream-mechanics-updates.yml
+++ b/.github/workflows/downstream-mechanics-updates.yml
@@ -34,7 +34,7 @@ jobs:
 
 
       - name: Run Mechanics File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1.7.1
+        uses: BetaHuhn/repo-file-sync-action@vv1.8.0
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
           COMMIT_BODY: release-${{ steps.get_tag.outputs.version }}

--- a/.github/workflows/downstream-mechanics-updates.yml
+++ b/.github/workflows/downstream-mechanics-updates.yml
@@ -34,7 +34,7 @@ jobs:
 
 
       - name: Run Mechanics File Sync
-        uses: BetaHuhn/repo-file-sync-action@vv1.8.0
+        uses: BetaHuhn/repo-file-sync-action@v1.8.0
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
           COMMIT_BODY: release-${{ steps.get_tag.outputs.version }}


### PR DESCRIPTION
Based on this thread exchange: https://github.com/BetaHuhn/repo-file-sync-action/issues/126#issuecomment-959801423
I'm making a simple change and I'm trying to use v1.8.0 of BetaHuhn/repo-file-sync-action and see if it still works. 

I won't merge to main since this might not work, I think I should be able to trigger from this branch. 