### PR TITLE
Get rid of assignment in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/course-content-add.md
+++ b/.github/ISSUE_TEMPLATE/course-content-add.md
@@ -3,7 +3,7 @@ name: New content idea
 about: Suggest an idea for the course
 title: ''
 labels: ''
-assignees: cansavvy
+assignees: 
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/course-content-add.md
+++ b/.github/ISSUE_TEMPLATE/course-content-add.md
@@ -3,15 +3,15 @@ name: New content idea
 about: Suggest an idea for the course
 title: ''
 labels: ''
-assignees: 
+assignees:
 
 ---
 
-**Describe the your scope of your content idea**
-What will this cover and how does it relate to the current course material?
+## Describe the your scope of your content idea
+<!-- What will this cover and how does it relate to the current course material? -->
 
-**Describe the learning objectives for your content idea**
-What will users learn from this new content? 
+## Describe the learning objectives for your content idea
+<!-- What will users learn from this new content? -->
 
-**Additional context or resources**
-Add any other context or related resources we should know about? 
+## Additional context or resources
+<!-- Add any other context or related resources we should know about? -->

--- a/.github/ISSUE_TEMPLATE/course-problem-report.md
+++ b/.github/ISSUE_TEMPLATE/course-problem-report.md
@@ -1,27 +1,28 @@
 ---
 name: Course Problem Report
 about: Create a report to help improve the course
-title: problem
+title: [Problem]
 labels: bug
-assignees: cansavvy
+assignees:
 
 ---
 
-**Describe what is not working with the course**
-A clear and concise description of what the bug is.
+## Describe what is not working with the course
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/course-template-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/course-template-feature-request.md
@@ -7,14 +7,14 @@ assignees: cansavvy
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe alternatives you've considered
+<!--  A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Additional context
+<!-- Add any other context or screenshots about the feature request here.  -->

--- a/.github/ISSUE_TEMPLATE/course-template-problem-report.md
+++ b/.github/ISSUE_TEMPLATE/course-template-problem-report.md
@@ -1,7 +1,7 @@
 ---
 name: Course Template Problem Report
 about: Create a report to help improve the template and its documentation
-title: problem
+title: [Problem]
 labels: bug
 assignees: cansavvy
 

--- a/.github/ISSUE_TEMPLATE/course-template-problem-report.md
+++ b/.github/ISSUE_TEMPLATE/course-template-problem-report.md
@@ -7,26 +7,26 @@ assignees: cansavvy
 
 ---
 
-**Describe what is not working with the template or is unclear in the documentation**
-A clear and concise description of what the bug is.
+## Describe what is not working with the template or is unclear in the documentation
+<!-- A clear and concise description of what the bug is. -->
 
-**Please link to the specific course repository you are working on**
+## Please link to the specific course repository you are working on
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## To Reproduce
+<!-- Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Github actions links**
-If applicable please link to the Github actions that has failed
+## Github actions links
+<!-- If applicable please link to the Github actions that has failed. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I realized in the issue templates I put myself as automatically being assigned, which is fine for this repo, but I don't want to be assigned to all the issues in the downstream repos! 🙀 

So I'm deleting this automatic assignment in the issue templates that get inherited by new courses created from this template. 

I'm also changing the prompts to html comments so you don't have to delete them if you don't want to. 