### PR TITLE
Return to pre-gist method of spell check

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -22,15 +22,3 @@ jobs:
         with:
           github_token: ${{ secrets.GH_PAT }}
           branches: preview-${{ github.event.pull_request.number }}
-
-      - name: Delete gist
-        id: gist
-        run: |
-          echo ${{ secrets.GH_PAT }} > docker/git_token.txt
-          gist_key=${GITHUB_REPOSITORY}_spell_check_${{ github.event.pull_request.number }}
-          gist_url=$(Rscript --vanilla scripts/get_the_gist.R \
-            --git_pat docker/git_token.txt \
-            --gist_key $gist_key \
-            --file resources/spell_check_results.tsv \
-            --delete)
-          rm docker/git_token.txt

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Commit rendered bookdown files to preview branch
         id: commit
         run: |
-          changes=$(git diff --name-only main -- docs)
+          changes=$(git diff --name-only -- docs)
 
           if [[ -z $changes ]]; then
             echo ::set-output name=changes::$(echo 'no_changes')

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -56,12 +56,12 @@ jobs:
       - name: Commit rendered bookdown files to preview branch
         id: commit
         run: |
+          git add . --force
+          git commit -m 'Render bookdown preview'
           changes=$(git diff --name-only `git log --format="%H" -n 1 origin/main` -- docs)
 
           if [[ -n $changes ]]; then
             echo ::set-output name=changes::$(echo 'changes')
-            git add . --force
-            git commit -m 'Render bookdown preview'
             git push --force origin "preview-${{ github.event.pull_request.number }}"
           else
             echo ::set-output name=changes::$(echo 'no_changes')

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Commit rendered bookdown files to preview branch
         id: commit
         run: |
-          changes=$(git diff --name-only origin/main -- docs)
+          changes=$(git diff --name-only main -- docs)
 
           if [[ -z $changes ]]; then
             echo ::set-output name=changes::$(echo 'no_changes')

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Commit rendered bookdown files to preview branch
         id: commit
         run: |
-          changes=$(git diff --name-only `git log --format="%H" -n 1 origin/main` -- docs)
+          changes=$(git diff --name-only origin/main -- docs)
 
           if [[ -z $changes ]]; then
             echo ::set-output name=changes::$(echo 'no_changes')

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           changes=$(git diff --name-only -- docs)
 
-          if [[ -z $changes ]]; then
+          if [ -z $changes ]; then
             echo ::set-output name=changes::$(echo 'no_changes')
           else
             echo ::set-output name=changes::$(echo 'changes')

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -56,15 +56,15 @@ jobs:
       - name: Commit rendered bookdown files to preview branch
         id: commit
         run: |
-          git add . --force
-          git commit -m 'Render bookdown preview'
           changes=$(git diff --name-only `git log --format="%H" -n 1 origin/main` -- docs)
 
-          if [[ -n $changes ]]; then
-            echo ::set-output name=changes::$(echo 'changes')
-            git push --force origin "preview-${{ github.event.pull_request.number }}"
-          else
+          if [[ -z $changes ]]; then
             echo ::set-output name=changes::$(echo 'no_changes')
+          else
+            echo ::set-output name=changes::$(echo 'changes')
+            git add . --force
+            git commit -m 'Render bookdown preview'
+            git push --force origin "preview-${{ github.event.pull_request.number }}"
           fi
 
       - name: Find Comment

--- a/.github/workflows/render-preview.yml
+++ b/.github/workflows/render-preview.yml
@@ -58,7 +58,8 @@ jobs:
         run: |
           changes=$(git diff --name-only -- docs)
 
-          if [ -z $changes ]; then
+          if -z $changes
+          then
             echo ::set-output name=changes::$(echo 'no_changes')
           else
             echo ::set-output name=changes::$(echo 'changes')

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -44,7 +44,7 @@ jobs:
           # Get on the preview branch if it exists. If it doesn't create it.
           branch_name='preview-${{ github.event.pull_request.number }}'
           git rev-parse --quiet --verify $branch_name >/dev/null && exists=true || exists=false
-          if [[ $exists == true ]];
+          if [ $exists == true ];
           then
             git checkout $branch_name
             git pull --set-upstream origin $branch_name --allow-unrelated-histories
@@ -65,7 +65,7 @@ jobs:
           echo ::set-output name=time::$(date +'%Y-%m-%d')
           echo ::set-output name=commit_id::$GITHUB_SHA
           echo ::set-output name=sp_error_url::$sp_error_url
-          
+
       # Handle the commenting
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -44,7 +44,7 @@ jobs:
           # Get on the preview branch if it exists. If it doesn't create it.
           branch_name='preview-${{ github.event.pull_request.number }}'
           git rev-parse --quiet --verify $branch_name >/dev/null && exists=true || exists=false
-          if [ $exists == true ];
+          if $exists == true
           then
             git checkout $branch_name
             git pull --set-upstream origin $branch_name --allow-unrelated-histories

--- a/.github/workflows/style-and-sp-check.yml
+++ b/.github/workflows/style-and-sp-check.yml
@@ -1,4 +1,3 @@
-
 # Candace Savonen Dec 2021
 
 name: Style and spell check R markdowns
@@ -34,34 +33,39 @@ jobs:
           results=$(Rscript "scripts/spell-check.R")
           echo "::set-output name=sp_chk_results::$results"
           cat resources/spell_check_results.tsv
-
       - name: Archive spelling errors
         uses: actions/upload-artifact@v2
         with:
           name: spell-check-results
           path: resources/spell_check_results.tsv
 
-      - name: Upload to Gist
-        id: gist
+      - name: Spell check errors
         run: |
-          echo ${{ secrets.GH_PAT }} > docker/git_token.txt
-          gist_key=${GITHUB_REPOSITORY}_spell_check_${{ github.event.pull_request.number }}
-          gist_url=$(Rscript --vanilla scripts/get_the_gist.R \
-            --git_pat docker/git_token.txt \
-            --gist_key $gist_key \
-            --file resources/spell_check_results.tsv)
-          echo "::set-output name=gist_url::$gist_url"
-          rm docker/git_token.txt
+          # Get on the preview branch if it exists. If it doesn't create it.
+          branch_name='preview-${{ github.event.pull_request.number }}'
+          git rev-parse --quiet --verify $branch_name >/dev/null && exists=true || exists=false
+          if [[ $exists == true ]];
+          then
+            git checkout $branch_name
+            git pull --set-upstream origin $branch_name --allow-unrelated-histories
+          else
+            git checkout -b $branch_name
+          fi
+          git add --force resources/spell_check_results.tsv
+          git commit -m 'Add spell check file'
+          git push --force --set-upstream origin $branch_name
 
       - name: Build components of the spell check comment
         id: build-components
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
+          branch_name='preview-${{ github.event.pull_request.number }}'
+          sp_error_url=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/spell_check_results.tsv
           echo ::set-output name=time::$(date +'%Y-%m-%d')
           echo ::set-output name=commit_id::$GITHUB_SHA
           echo ::set-output name=sp_error_url::$sp_error_url
-
+          
       # Handle the commenting
       - name: Find Comment
         uses: peter-evans/find-comment@v1
@@ -79,8 +83,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             :warning: There are spelling errors that need to be addressed. [Read this guide for more info](https://github.com/jhudsl/OTTR_Template/wiki/Spell-check).
-
-            [Download the errors here.](${{ steps.gist.outputs.gist_url }})
+            [Download the errors here.](${{ steps.build-components.outputs.sp_error_url }})
             _Comment updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
@@ -96,7 +99,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             No spelling errors! :tada:
-
             _Comment updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
@@ -106,5 +108,6 @@ jobs:
       - name: Commit styled files
         run: |
           git add \*.Rmd
+          git add resources/spell_check_results.tsv
           git commit -m 'Style Rmds' || echo "No changes to commit"
           git push origin || echo "No changes to commit"

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -16,7 +16,3 @@ The course is intended for ...
 ## Curriculum  
 
 The course covers...
-
-wheuihf
-wuibguiwef
-gwueigwie

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -16,3 +16,7 @@ The course is intended for ...
 ## Curriculum  
 
 The course covers...
+
+wheuihf
+wuibguiwef
+gwueigwie


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

I'm undoing the gist strategy for spell check #405 because it won't work for people not in jhudsl at this time. 

This method is still stored on the `staging` branch though, because if I figure out a way to more seamless manage the permissions for the jhudsl-robot gist, then we can use that method again. 

In the meantime I don't want new repos made with the template to have the gist method though. 
