### PR TITLE
Docker CRAN mirror setting issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y --no-install-recommends install \
     python3-pip  python3-dev
 
 # Commonly used R packages
-RUN Rscript -e  "install.packages( \
+RUN Rscript -e  "options(warn = 2);install.packages( \
     c('bookdown', \
       'here', \
       'leanpubr', \
@@ -56,7 +56,8 @@ RUN Rscript -e  "install.packages( \
       'servr', \
       'spelling', \
       'styler', \
-      'reticulate'))"
+      'reticulate'), \
+      repos = 'https://cloud.r-project.org/')"
 
 # cow needs this dependency:
 RUN Rscript -e  "devtools::install_version('gitcreds', version = '0.1.1', repos = 'http://cran.us.r-project.org')"

--- a/resources/TEMPLATE_Dockerfile
+++ b/resources/TEMPLATE_Dockerfile
@@ -1,8 +1,6 @@
 FROM jhudsl/course_template
 LABEL maintainer="your_email.com"
 
-RUN R -e "options(warn = 2); install.packages(c('OCSdata'), repos='https://cloud.r-project.org/')"
-
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################
 # Install a Linux/Ubuntu package
 # RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/resources/TEMPLATE_Dockerfile
+++ b/resources/TEMPLATE_Dockerfile
@@ -1,14 +1,17 @@
 FROM jhudsl/course_template
 LABEL maintainer="your_email.com"
 
+RUN R -e "options(warn = 2); install.packages(c('OCSdata'), repos='https://cloud.r-project.org/')"
+
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################
 # Install a Linux/Ubuntu package
 # RUN apt-get update && apt-get install -y --no-install-recommends \
 #    package_name
 
 # Install a package from CRAN
-# RUN Rscript -e  "install.packages( \
-#    c('package_name'))"
+# RUN Rscript -e  "options(warn = 2);install.packages( \
+#    c('package_name'), \
+#    repos = 'https://cloud.r-project.org/')"
 
 # Install a package from Bioconductor
 # RUN Rscript -e "options(warn = 2); BiocManager::install( \


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

This is related to #432 

There are two things needed to get around this problem that are added here to the TEMPLATE_Dockerfile as well as the Dockerfile itself. 

1) `options(warn= 2)` makes sure that if the package isn't found or doesn't install the docker build fails. 
2) ` repos = 'https://cloud.r-project.org/'` specfies the CRAN so we make sure we're pulling from an updated one.

I tested this by building an image with the `OCSdata` package installed this way and started a container with that built image and it did indeed install `OCSdata`.