### PR TITLE
Disentangle bookdown/coursera/leanpub rendering. 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -327,6 +327,8 @@ jobs:
         run: Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
 
       # Run TOC-less version
+      # Rendered content for Leanpub and Coursera is very similar. 
+      # This job creates a shared scaffold for both.
       - name: Run TOC-less version of render
         id: tocless
         run: Rscript -e "ottr::render_without_toc()"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -345,6 +345,8 @@ jobs:
         id: commit
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
+          git diff --name-only origin/main -- docs >/dev/null && changes=true || changes=false
+          echo ::set-output name=changes::$(echo $changes)
           git add . --force
           git commit -m 'Render preview' || echo "No changes to commit"
           git pull --set-upstream origin $branch_name --allow-unrelated-histories
@@ -388,8 +390,8 @@ jobs:
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
-      - name: comment if no changes
-        if: ${{ steps.commit.outputs.changes == 'no_changes' }}
+      - name: Comment if no changes
+        if: steps.commit.outputs.changes == 'no_changes'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -345,8 +345,8 @@ jobs:
         id: commit
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
-          git diff --name-only origin/main -- docs >/dev/null && changes=true || changes=false
-          echo ::set-output name=changes::$(echo $changes)
+          git diff origin/main -- docs >/dev/null && changes=true || changes=false
+          echo ::set-output name=changes::$changes
           git add . --force
           git commit -m 'Render preview' || echo "No changes to commit"
           git pull --set-upstream origin $branch_name --allow-unrelated-histories
@@ -376,7 +376,7 @@ jobs:
           echo ${{steps.commit.outputs.changes}}
 
       - name: Create or update comment
-        if: steps.commit.outputs.changes == 'changes'
+        if: steps.commit.outputs.changes == 'true'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -391,7 +391,7 @@ jobs:
           edit-mode: replace
 
       - name: Comment if no changes
-        if: steps.commit.outputs.changes == 'no_changes'
+        if: steps.commit.outputs.changes == 'false'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -326,18 +326,18 @@ jobs:
         id: bookdown
         run: Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
 
-      # Run Coursera version
-      - name: Run Coursera version of render
-        id: coursera
-        run: Rscript -e "ottr::render_coursera()"
+      # Run TOC-less version
+      - name: Run TOC-less version of render
+        id: tocless
+        run: Rscript -e "ottr::render_without_toc()"
 
       # This checks on the steps before it and makes sure that they completed.
       # If the renders didn't complete we don't want to commit the file changes
       - name: Check on render steps
-        if: steps.bookdown.outcome != 'success' || steps.coursera.outcome != 'success'
+        if: steps.bookdown.outcome != 'success' || steps.tocless.outcome != 'success'
         run: |
           echo Bookdown status ${{steps.bookdown.outcome}}
-          echo Coursera status ${{steps.coursera.outcome}}
+          echo Toc-less status ${{steps.tocless.outcome}}
           exit 1
 
       # Commit the rendered bookdown files
@@ -346,7 +346,7 @@ jobs:
         run: |
           branch_name='preview-${{ github.event.pull_request.number }}'
           git add . --force
-          git commit -m 'Render bookdown preview' || echo "No changes to commit"
+          git commit -m 'Render preview' || echo "No changes to commit"
           git pull --set-upstream origin $branch_name --allow-unrelated-histories
           git push --force || echo "No changes to commit"
         shell: bash
@@ -364,10 +364,10 @@ jobs:
         run: |
           course_name=$(head -n 1 _bookdown.yml | cut -d'"' -f 2| tr " " "-")
           bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
-          coursera_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/coursera/index.html")
+          tocless_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/no_toc/index.html")
           docx_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/docs/$course_name.docx")
           echo ::set-output name=bookdown_link::$bookdown_link
-          echo ::set-output name=coursera_link::$coursera_link
+          echo ::set-output name=tocless_link::$tocless_link
           echo ::set-output name=docx_link::$docx_link
           echo ::set-output name=time::$(date +'%Y-%m-%d')
           echo ::set-output name=commit_id::$GITHUB_SHA
@@ -382,14 +382,14 @@ jobs:
           body: |
             Re-rendered previews from the latest commit:
             - See [preview of Bookdown here](${{ steps.build-components.outputs.bookdown_link }})
-            - See [preview of Coursera version here](${{ steps.build-components.outputs.coursera_link }})
+            - See [preview of Coursera/Leanpub version here](${{ steps.build-components.outputs.tocless_link }})
             - Download the [preview of .docx file](${{ steps.build-components.outputs.docx_link }})
 
             _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
-      - name: No comment if no changes
-        if: steps.commit.outputs.changes == 'no_changes'
+      - name: comment if no changes
+        if: ${{ steps.commit.outputs.changes == 'no_changes' }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -132,19 +132,10 @@ jobs:
       - name: Delete old manuscript/
         run: rm -rf manuscript/
 
-      - name: Run ottr::bookdown_to_embed_leanpub -- without re-render
-        if: ${{ needs.yaml-check.outputs.toggle_bookdown == 'yes'}}
+      - name: Run ottr::bookdown_to_embed_leanpub
         run: |
           Rscript -e "ottr::bookdown_to_embed_leanpub(
             render = FALSE \
-            chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = TRUE)"
-
-      - name: Run ottr::bookdown_to_embed_leanpub -- with re-render
-        if: ${{ needs.yaml-check.outputs.toggle_bookdown == 'no'}}
-        run: |
-          rm -r docs/*
-          Rscript -e "ottr::bookdown_to_embed_leanpub(
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
             make_book_txt = TRUE)"
 

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -87,7 +87,8 @@ jobs:
     if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes' || needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
 
     steps:
-      # Run TOC-less version
+      # Rendered content for Leanpub and Coursera is very similar.
+      # This job creates a shared scaffold for both.
       - name: Run TOC-less version of render
         id: tocless
         run: Rscript -e "ottr::render_without_toc()"
@@ -102,7 +103,7 @@ jobs:
           git push origin main || echo "No changes to push"
 
   render-leanpub:
-    name: Render Leanpub
+    name: Finish Leanpub prep
     needs: [yaml-check, render-tocless]
     runs-on: ubuntu-latest
     container:
@@ -149,7 +150,7 @@ jobs:
           git push --force origin main || echo "No changes to push"
 
   render-coursera:
-    name: Render Coursera
+    name: Finish Coursera prep
     needs: [yaml-check, render-tocless]
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -78,51 +78,9 @@ jobs:
           git commit -m 'Render bookdown' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
 
-  render-coursera:
-    name: Render Coursera
-    needs: [yaml-check, render-bookdown]
-    runs-on: ubuntu-latest
-    container:
-      image: jhudsl/course_template
-    if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes'}}
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Login as jhudsl-robot
-        run: |
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
-
-      # Run Coursera version
-      - name: Run Coursera version of render
-        id: coursera
-        run: Rscript -e "ottr::render_coursera(convert_quizzes = TRUE)"
-
-      # This checks on the steps before it and makes sure that they completed.
-      # If the renders didn't complete we don't want to commit the file changes
-      - name: Check on render steps
-        if: steps.coursera.outcome != 'success'
-        run: |
-          echo Coursera status ${{steps.coursera.outcome}}
-          exit 1
-
-      # Commit the rendered bookdown files
-      - name: Commit rendered Coursera files
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git add --force docs/coursera/*
-          git commit -m 'Render Coursera' || echo "No changes to commit"
-          git push origin main || echo "No changes to push"
-
   render-leanpub:
     name: Render Leanpub
-    needs: [yaml-check, render-coursera]
+    needs: [yaml-check]
     runs-on: ubuntu-latest
     container:
       image: jhudsl/ottr
@@ -139,6 +97,11 @@ jobs:
         run: |
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
+
+      # Run TOC less version
+      - name: Run tocless version of render
+        id: no_toc
+        run: Rscript -e "ottr::render_coursera()"
 
       # Create screenshots
       - name: Run the screenshot creation
@@ -166,3 +129,45 @@ jobs:
           git add --force manuscript/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
           git push --force origin main || echo "No changes to push"
+
+  render-coursera:
+    name: Render Coursera
+    needs: [yaml-check, render-leanpub]
+    runs-on: ubuntu-latest
+    container:
+      image: jhudsl/course_template
+    if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes'}}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Login as jhudsl-robot
+        run: |
+          git config --local user.email "itcrtrainingnetwork@gmail.com"
+          git config --local user.name "jhudsl-robot"
+
+      # Run Coursera version
+      - name: Run Coursera version of render
+        id: coursera
+        run: Rscript -e "ottr::convert_coursera_quizzes()"
+
+      # This checks on the steps before it and makes sure that they completed.
+      # If the renders didn't complete we don't want to commit the file changes
+      - name: Check on render steps
+        if: steps.coursera.outcome != 'success'
+        run: |
+          echo Coursera status ${{steps.coursera.outcome}}
+          exit 1
+
+      # Commit the rendered bookdown files
+      - name: Commit rendered Coursera files
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add --force docs/coursera/*
+          git commit -m 'Render Coursera quizzes' || echo "No changes to commit"
+          git push origin main || echo "No changes to push"

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git add --force docs/*
+          git add --force docs/no_toc*
           git commit -m 'Render toc-less' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
 

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -78,9 +78,32 @@ jobs:
           git commit -m 'Render bookdown' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
 
+  render-tocless:
+    name: Render TOC-less version for Leanpub or Coursera
+    needs: [yaml-check]
+    runs-on: ubuntu-latest
+    container:
+      image: jhudsl/ottr
+    if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes' || needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
+
+    steps:
+      # Run TOC-less version
+      - name: Run TOC-less version of render
+        id: tocless
+        run: Rscript -e "ottr::render_without_toc()"
+
+      # Commit the TOC-less version files
+      - name: Commit tocless bookdown files
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add --force docs/*
+          git commit -m 'Render toc-less' || echo "No changes to commit"
+          git push origin main || echo "No changes to push"
+
   render-leanpub:
     name: Render Leanpub
-    needs: [yaml-check]
+    needs: [yaml-check, render-tocless]
     runs-on: ubuntu-latest
     container:
       image: jhudsl/ottr
@@ -98,11 +121,6 @@ jobs:
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
-      # Run TOC less version
-      - name: Run tocless version of render
-        id: no_toc
-        run: Rscript -e "ottr::render_coursera()"
-
       # Create screenshots
       - name: Run the screenshot creation
         run: |
@@ -114,10 +132,19 @@ jobs:
       - name: Delete old manuscript/
         run: rm -rf manuscript/
 
-      # Run Leanpub rendering
-      - name: Run ottr::bookdown_to_embed_leanpub
+      - name: Run ottr::bookdown_to_embed_leanpub -- without re-render
+        if: ${{ needs.yaml-check.outputs.toggle_bookdown == 'yes'}}
         run: |
-          Rscript -e "ottr::bookdown_to_embed_leanpub( \
+          Rscript -e "ottr::bookdown_to_embed_leanpub(
+            render = FALSE \
+            chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
+            make_book_txt = TRUE)"
+
+      - name: Run ottr::bookdown_to_embed_leanpub -- with re-render
+        if: ${{ needs.yaml-check.outputs.toggle_bookdown == 'no'}}
+        run: |
+          rm -r docs/*
+          Rscript -e "ottr::bookdown_to_embed_leanpub(
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
             make_book_txt = TRUE)"
 
@@ -132,7 +159,7 @@ jobs:
 
   render-coursera:
     name: Render Coursera
-    needs: [yaml-check, render-leanpub]
+    needs: [yaml-check, render-tocless]
     runs-on: ubuntu-latest
     container:
       image: jhudsl/course_template


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

`render_coursera()` function is actually just "render_without_toc" but Leanpub also needs a toc-less version. 

I'm working on disentangling the renders from each other so someone can truly specify just one and not the others. Before Leanpub was dependent on Coursera which was dependent on Bookdown. 

Now, my hope is you can really just choose one and not the others (although really Bookdown is still run underneath the hood for all)

Over in the `ottr` package, I renamed `render_coursera` to `render_without_toc()` so this is less confusing. https://github.com/jhudsl/ottr/pull/96
