### PR TITLE
Save url check to a file like the other checks do

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -183,10 +183,16 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
 
-    - name: Login as jhudsl-robot
-      run: |
-        git config --local user.email "itcrtrainingnetwork@gmail.com"
-        git config --local user.name "jhudsl-robot"
+      - name: Configure git
+        run: |
+          git config --local user.email "itcrtrainingnetwork@gmail.com"
+          git config --local user.name "jhudsl-robot"
+
+          branch_name='preview-${{ github.event.pull_request.number }}'
+          git fetch --all
+          git checkout $branch_name
+          git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
+        shell: bash
 
     - name: URLs checker
       uses: urlstechie/urlchecker-action@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -211,6 +211,8 @@ jobs:
         # Choose whether to include file with no URLs in the prints.
         print_all: false
 
+        exclude_files: .github/PULL_REQUEST_TEMPLATE.md
+
         # A comma separated links to exclude during URL checks
         exclude_urls: https://jhudatascience.org/{Course_Name}}
 
@@ -277,7 +279,7 @@ jobs:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          There are no broken URLs detected! :tada:
+          No broken URLs detected! :tada:
           _Comment updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
         edit-mode: replace
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -187,18 +187,16 @@ jobs:
       run: |
         git config --local user.email "itcrtrainingnetwork@gmail.com"
         git config --local user.name "jhudsl-robot"
-
-        branch_name='preview-${{ github.event.pull_request.number }}'
-        git fetch --all
-        git checkout $branch_name
-        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
       shell: bash
 
     - name: URLs checker
       uses: urlstechie/urlchecker-action@master
       with:
-        # Delete the cloned repository after running URL checked (default is false)
-        cleanup: true
+        # Specify a branch
+        branch: ${{ github.head_ref }}
+
+        # Cleanup
+        cleanup: false
 
         # A comma-separated list of file types to cover in the URL checks
         file_types: .Rmd,.md
@@ -218,8 +216,8 @@ jobs:
       id: url_errors
       run: |
         results=0
-        if -f "resources/url_checks.tsv"; then
-          results=$(wc -l < resources/url_checks.tsv >/dev/null)
+        if -f "/github/workspace/resources/url_checks.tsv"; then
+          results=$(wc -l < /github/workspace/resources/url_checks.tsv >/dev/null)
         fi
         echo ::set-output name=url_results::$results
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -183,16 +183,16 @@ jobs:
     - name: checkout repo
       uses: actions/checkout@v2
 
-      - name: Configure git
-        run: |
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+    - name: Configure git
+      run: |
+        git config --local user.email "itcrtrainingnetwork@gmail.com"
+        git config --local user.name "jhudsl-robot"
 
-          branch_name='preview-${{ github.event.pull_request.number }}'
-          git fetch --all
-          git checkout $branch_name
-          git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
-        shell: bash
+        branch_name='preview-${{ github.event.pull_request.number }}'
+        git fetch --all
+        git checkout $branch_name
+        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
+      shell: bash
 
     - name: URLs checker
       uses: urlstechie/urlchecker-action@master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -220,11 +220,8 @@ jobs:
     - name: Count URL errors
       id: url_errors
       run: |
-        results=0
-        if [ -f resources/url_checks.csv]; then
-          results=$(wc -l < /resources/url_checks.csv >/dev/null)
-        fi
-        echo ::set-output name=url_results::$results
+        results=$(Rscript "scripts/url-check.R")
+        echo "::set-output name=url_results::$results"
 
     - name: Commit URL check
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -187,6 +187,11 @@ jobs:
       run: |
         git config --local user.email "itcrtrainingnetwork@gmail.com"
         git config --local user.name "jhudsl-robot"
+
+        branch_name='preview-${{ github.event.pull_request.number }}'
+        git fetch --all
+        git checkout $branch_name
+        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
       shell: bash
 
     - name: URLs checker
@@ -211,13 +216,6 @@ jobs:
 
         # A path to a csv file to save results to
         save: resources/url_checks.tsv
-
-    - name: Git set up
-      run: |
-        branch_name='preview-${{ github.event.pull_request.number }}'
-        git fetch --all
-        git checkout $branch_name
-        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
 
     - name: Count URL errors
       id: url_errors

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -212,6 +212,13 @@ jobs:
         # A path to a csv file to save results to
         save: resources/url_checks.tsv
 
+    - name: Git set up
+      run: |
+        branch_name='preview-${{ github.event.pull_request.number }}'
+        git fetch --all
+        git checkout $branch_name
+        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
+
     - name: Count URL errors
       id: url_errors
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -209,6 +209,43 @@ jobs:
         # A path to a csv file to save results to
         save: resources/url_checks.tsv
 
+      - name: Commit URL check
+        run: |
+          branch_name='preview-${{ github.event.pull_request.number }}'
+          git add --force resources/url_checks.tsv || echo "No changes to commit"
+          git commit -m 'Add URL check file' || echo "No changes to commit"
+          git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
+          git push --force origin $branch_name || echo "No changes to commit"
+
+      - name: Build components of the spell check comment
+        id: build-components
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          branch_name='preview-${{ github.event.pull_request.number }}'
+          url_errors=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/url_checks.tsv
+          echo ::set-output name=time::$(date +'%Y-%m-%d')
+          echo ::set-output name=commit_id::$GITHUB_SHA
+          echo ::set-output name=url_errors::$url_errors
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: URL check results
+
+      - name: URL checks
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            See URL check results here:
+            _Comment updated at ${{ steps.build-components.outputs.url_errors }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+          edit-mode: replace
+
   check-quizzes:
     name: Check Leanpub quizzes
     needs: yaml-check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -193,7 +193,7 @@ jobs:
       uses: urlstechie/urlchecker-action@master
       with:
         # Specify a branch
-        branch: ${{ github.head_ref }}
+        branch: preview-${{ github.event.pull_request.number }}
 
         # Cleanup
         cleanup: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -311,7 +311,7 @@ jobs:
         run: |
           Rscript -e "ottrpal::check_quizzes(quiz_dir = 'quizzes', write_report = TRUE, verbose = TRUE)"
           results=0
-          if [ -f question_error_report.tsv]; then
+          if [ -f question_error_report.tsv ]; then
             results=$(wc -l < question_error_report.tsv >/dev/null)
           fi
           echo ::set-output name=quiz_chk_results::$results

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -231,7 +231,8 @@ jobs:
         branch_name='preview-${{ github.event.pull_request.number }}'
         git add --force resources/url_checks.tsv || echo "No changes to commit"
         git commit -m 'Add URL check file' || echo "No changes to commit"
-        git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
+        git config pull.rebase false
+        git pull --set-upstream origin $branch_name --strategy-option=ours --allow-unrelated-histories
         git push --force origin $branch_name || echo "No changes to commit"
 
     - name: Build components of the spell check comment

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -221,8 +221,8 @@ jobs:
       id: url_errors
       run: |
         results=0
-        if -f "resources/url_checks.tsv"; then
-          results=$(wc -l < /github/workspace/resources/url_checks.tsv >/dev/null)
+        if [ -f resources/url_checks.tsv]; then
+          results=$(wc -l < /resources/url_checks.tsv >/dev/null)
         fi
         echo ::set-output name=url_results::$results
 
@@ -311,7 +311,7 @@ jobs:
         run: |
           Rscript -e "ottrpal::check_quizzes(quiz_dir = 'quizzes', write_report = TRUE, verbose = TRUE)"
           results=0
-          if -f "question_error_report.tsv"; then
+          if [ -f question_error_report.tsv]; then
             results=$(wc -l < question_error_report.tsv >/dev/null)
           fi
           echo ::set-output name=quiz_chk_results::$results

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -188,7 +188,7 @@ jobs:
         git config --local user.email "itcrtrainingnetwork@gmail.com"
         git config --local user.name "jhudsl-robot"
 
-    - name: URLs-checker
+    - name: URLs checker
       uses: urlstechie/urlchecker-action@master
       with:
         # Delete the cloned repository after running URL checked (default is false)
@@ -202,9 +202,6 @@ jobs:
 
         # A comma separated links to exclude during URL checks
         exclude_urls: https://jhudatascience.org/{Course_Name}}
-
-        # choose if the force pass or not
-        force_pass : true
 
         # A path to a csv file to save results to
         save: resources/url_checks.tsv

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -211,7 +211,7 @@ jobs:
         # Choose whether to include file with no URLs in the prints.
         print_all: false
 
-        exclude_files: .github/PULL_REQUEST_TEMPLATE.md
+        exclude_files: .github/PULL_REQUEST_TEMPLATE.md, docs/*
 
         # A comma separated links to exclude during URL checks
         exclude_urls: https://jhudatascience.org/{Course_Name}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -203,8 +203,19 @@ jobs:
         # A comma separated links to exclude during URL checks
         exclude_urls: https://jhudatascience.org/{Course_Name}}
 
+        force_pass: true
+
         # A path to a csv file to save results to
         save: resources/url_checks.tsv
+
+    - name: Count URL errors
+      id: url_errors
+      run: |
+        results=0
+        if -f "resources/url_checks.tsv"; then
+          results=$(wc -l < resources/url_checks.tsv >/dev/null)
+        fi
+        echo ::set-output name=url_results::$results
 
     - name: Commit URL check
       run: |
@@ -225,22 +236,40 @@ jobs:
         echo ::set-output name=commit_id::$GITHUB_SHA
         echo ::set-output name=url_errors::$url_errors
 
+    # Handle the commenting
     - name: Find Comment
       uses: peter-evans/find-comment@v1
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
-        body-includes: URL check results
+        body-includes: broken URLs
 
-    - name: URL checks
+    - name: URL errors!
+      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          See URL check results here:
-          _Comment updated at ${{ steps.build-components.outputs.url_errors }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+          :warning: There are broken URLs that need to be addressed. [Read this guide for more info](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots#check-for-broken-urls).
+          [Download the errors here.](${{ steps.build-components.outputs.url_errors }})
+          _Comment updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+        edit-mode: replace
+
+    - name: Check URL results - fail if too many errors
+      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
+      run: exit 1
+
+    - name: No URL errors
+      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          There are no broken URLs detected! :tada:
+          _Comment updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
         edit-mode: replace
 
   check-quizzes:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -215,14 +215,14 @@ jobs:
         force_pass: true
 
         # A path to a csv file to save results to
-        save: resources/url_checks.tsv
+        save: resources/url_checks.csv
 
     - name: Count URL errors
       id: url_errors
       run: |
         results=0
-        if [ -f resources/url_checks.tsv]; then
-          results=$(wc -l < /resources/url_checks.tsv >/dev/null)
+        if [ -f resources/url_checks.csv]; then
+          results=$(wc -l < /resources/url_checks.csv >/dev/null)
         fi
         echo ::set-output name=url_results::$results
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -223,7 +223,7 @@ jobs:
       id: url_errors
       run: |
         results=0
-        if -f "/github/workspace/resources/url_checks.tsv"; then
+        if -f "resources/url_checks.tsv"; then
           results=$(wc -l < /github/workspace/resources/url_checks.tsv >/dev/null)
         fi
         echo ::set-output name=url_results::$results
@@ -273,7 +273,7 @@ jobs:
       run: exit 1
 
     - name: No URL errors
-      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
+      if: ${{ steps.quiz_check_run.outputs.url_results == 0 }}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -256,7 +256,7 @@ jobs:
         body-includes: broken URLs
 
     - name: URL errors!
-      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
+      if: ${{ steps.url_errors.outputs.url_results > 0 }}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -268,11 +268,11 @@ jobs:
         edit-mode: replace
 
     - name: Check URL results - fail if too many errors
-      if: ${{ steps.quiz_check_run.outputs.url_results > 0 }}
+      if: ${{ steps.url_errors.outputs.url_results > 0 }}
       run: exit 1
 
     - name: No URL errors
-      if: ${{ steps.quiz_check_run.outputs.url_results == 0 }}
+      if: ${{ steps.url_errors.outputs.url_results == 0 }}
       uses: peter-evans/create-or-update-comment@v1
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -241,7 +241,7 @@ jobs:
         GH_PAT: ${{ secrets.GH_PAT }}
       run: |
         branch_name='preview-${{ github.event.pull_request.number }}'
-        url_errors=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/url_checks.tsv
+        url_errors=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/url_checks.csv
         echo ::set-output name=time::$(date +'%Y-%m-%d')
         echo ::set-output name=commit_id::$GITHUB_SHA
         echo ::set-output name=url_errors::$url_errors

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -206,42 +206,42 @@ jobs:
         # A path to a csv file to save results to
         save: resources/url_checks.tsv
 
-      - name: Commit URL check
-        run: |
-          branch_name='preview-${{ github.event.pull_request.number }}'
-          git add --force resources/url_checks.tsv || echo "No changes to commit"
-          git commit -m 'Add URL check file' || echo "No changes to commit"
-          git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
-          git push --force origin $branch_name || echo "No changes to commit"
+    - name: Commit URL check
+      run: |
+        branch_name='preview-${{ github.event.pull_request.number }}'
+        git add --force resources/url_checks.tsv || echo "No changes to commit"
+        git commit -m 'Add URL check file' || echo "No changes to commit"
+        git pull --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
+        git push --force origin $branch_name || echo "No changes to commit"
 
-      - name: Build components of the spell check comment
-        id: build-components
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-        run: |
-          branch_name='preview-${{ github.event.pull_request.number }}'
-          url_errors=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/url_checks.tsv
-          echo ::set-output name=time::$(date +'%Y-%m-%d')
-          echo ::set-output name=commit_id::$GITHUB_SHA
-          echo ::set-output name=url_errors::$url_errors
+    - name: Build components of the spell check comment
+      id: build-components
+      env:
+        GH_PAT: ${{ secrets.GH_PAT }}
+      run: |
+        branch_name='preview-${{ github.event.pull_request.number }}'
+        url_errors=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/$branch_name/resources/url_checks.tsv
+        echo ::set-output name=time::$(date +'%Y-%m-%d')
+        echo ::set-output name=commit_id::$GITHUB_SHA
+        echo ::set-output name=url_errors::$url_errors
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: URL check results
+    - name: Find Comment
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: URL check results
 
-      - name: URL checks
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            See URL check results here:
-            _Comment updated at ${{ steps.build-components.outputs.url_errors }} with changes from ${{ steps.build-components.outputs.commit_id }}_
-          edit-mode: replace
+    - name: URL checks
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          See URL check results here:
+          _Comment updated at ${{ steps.build-components.outputs.url_errors }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+        edit-mode: replace
 
   check-quizzes:
     name: Check Leanpub quizzes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -178,7 +178,9 @@ jobs:
     needs: yaml-check
     runs-on: ubuntu-latest
     if: ${{needs.yaml-check.outputs.toggle_url_check == 'yes'}}
-
+    container:
+      image: jhudsl/course_template:main
+      
     steps:
     - name: checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -231,8 +231,8 @@ jobs:
         branch_name='preview-${{ github.event.pull_request.number }}'
         git add --force resources/url_checks.tsv || echo "No changes to commit"
         git commit -m 'Add URL check file' || echo "No changes to commit"
-        git config pull.rebase false
-        git pull --set-upstream origin $branch_name --strategy-option=ours --allow-unrelated-histories
+        git fetch
+        git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}
         git push --force origin $branch_name || echo "No changes to commit"
 
     - name: Build components of the spell check comment

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -191,7 +191,7 @@ jobs:
     - name: URLs-checker
       uses: urlstechie/urlchecker-action@master
       with:
-        # Delete the cloned repository after running URLchecked (default is false)
+        # Delete the cloned repository after running URL checked (default is false)
         cleanup: true
 
         # A comma-separated list of file types to cover in the URL checks
@@ -205,6 +205,9 @@ jobs:
 
         # choose if the force pass or not
         force_pass : true
+
+        # A path to a csv file to save results to
+        save: resources/url_checks.tsv
 
   check-quizzes:
     name: Check Leanpub quizzes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -180,7 +180,7 @@ jobs:
     if: ${{needs.yaml-check.outputs.toggle_url_check == 'yes'}}
     container:
       image: jhudsl/course_template:main
-      
+
     steps:
     - name: checkout repo
       uses: actions/checkout@v2
@@ -228,7 +228,7 @@ jobs:
     - name: Commit URL check
       run: |
         branch_name='preview-${{ github.event.pull_request.number }}'
-        git add --force resources/url_checks.tsv || echo "No changes to commit"
+        git add --force resources/url_checks.csv || echo "No changes to commit"
         git commit -m 'Add URL check file' || echo "No changes to commit"
         git fetch
         git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }}

--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -96,16 +96,16 @@ OR this works:
 This works:
 
 ```{r, fig.align="center", echo=FALSE}
-knitr::include_url("https://www.messiah.edu/download/downloads/id/921/Microaggressions_in_the_Classroom.pdf", height = "800px")
+knitr::include_url("https://www.bgsu.edu/content/dam/BGSU/center-for-faculty-excellence/docs/TLGuides/TLGuide-Learning-Objectives.pdf", height = "800px")
 ```
 
 Or this:
 
-[This works](https://www.messiah.edu/download/downloads/id/921/Microaggressions_in_the_Classroom.pdf).
+[This works](https://www.bgsu.edu/content/dam/BGSU/center-for-faculty-excellence/docs/TLGuides/TLGuide-Learning-Objectives.pdf).
 
 Or this:
 
-<iframe src="https://www.messiah.edu/download/downloads/id/921/Microaggressions_in_the_Classroom.pdf" width="672" height="800px"></iframe>
+<iframe src="https://www.bgsu.edu/content/dam/BGSU/center-for-faculty-excellence/docs/TLGuides/TLGuide-Learning-Objectives.pdf" width="672" height="800px"></iframe>
 
 ### Links to websites
 

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -1,0 +1,27 @@
+#!/usr/bin/env Rscript
+
+# Adapted for this jhudsl repository by Candace Savonen Mar 2022
+
+# Summarize url checks
+
+library(magrittr)
+
+# Find .git root directory
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+
+# Read in dictionary
+url_checks <- readr::read_csv(file.path(root_dir, 'resources', 'url_checks.csv'))
+
+if (nrow(url_checks) > 0) {
+  url_checks <- url_checks %>%
+    data.frame() %>%
+    dplyr::filter(RESULT == "failed")
+}
+
+# Print out how many spell check errors
+write(nrow(url_checks), stdout())
+
+if (nrow(url_checks) > 0) {
+# Save spell errors to file temporarily
+readr::write_tsv(url_checks, file.path('resources', 'url_checks.csv'))
+}

--- a/scripts/url-check.R
+++ b/scripts/url-check.R
@@ -23,5 +23,5 @@ write(nrow(url_checks), stdout())
 
 if (nrow(url_checks) > 0) {
 # Save spell errors to file temporarily
-readr::write_tsv(url_checks, file.path('resources', 'url_checks.csv'))
+readr::write_csv(url_checks, file.path('resources', 'url_checks.csv'))
 }


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

If there is a broken URL, its tricky to find and I think its been sneaking by us. 
This PR adds the mechanics to have it print out like we do for spell and quiz checks. 

Note: I don't like how much of the handling is repetitive, I think later I will try to condense some of the comment and git checkout items. 

Also later, I'll want to put all the checks into one comment #492 
