### PR TITLE
Add simplified custom workflow capability 

### DIFF
--- a/.github/workflows/custom-workflow.yml
+++ b/.github/workflows/custom-workflow.yml
@@ -3,6 +3,12 @@ name: Custom Workflow
 
 on:
   workflow_call:
+    inputs:
+      # render-type is passed through pull-request or render-all workflows.
+      # It allows different branches to be used upon commit / push.
+      render-type: 
+        required: true
+        type: string
 
 jobs:
   custom-job:
@@ -16,4 +22,18 @@ jobs:
         with:
           fetch-depth: 0
           
-# Add your custom workflow steps here          
+      - name: Run if rendering preview
+        # Include the following conditional to only run on pull request
+        if: ${{ inputs.render-type == 'preview' }}
+        run: |
+          echo "preview branch"
+          
+      - name: Run if rendering preview
+        # Include the following conditional to only run on push to staging or
+        # main
+        if: ${{ inputs.render-type == 'preview' }}
+        run: |
+          echo "main branch"
+          
+# Add your custom workflow steps here     
+# For ideas, see https://github.com/jhudsl/AnVIL_Template/blob/main/.github/workflows/custom-workflow.yml

--- a/.github/workflows/custom-workflow.yml
+++ b/.github/workflows/custom-workflow.yml
@@ -1,0 +1,19 @@
+
+name: Custom Workflow
+
+on:
+  workflow_call:
+
+jobs:
+  custom-job:
+    runs-on: ubuntu-latest
+    container:
+      image: jhudsl/course_template:main
+
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          
+# Add your custom workflow steps here          

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,6 +57,11 @@ jobs:
       rendering_docker_image: "${{ env.RENDERING_DOCKER_IMAGE }}"
       dockerfiles_changed: steps.verify-changed-files.outputs.files_changed
 
+  call-custom-workflow:
+    name: Custom Workflow
+    needs: yaml-check
+    uses: ./.github/workflows/custom-workflow.yml
+
   spell-check:
     name: Check spelling
     needs: yaml-check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,6 +61,8 @@ jobs:
     name: Custom Workflow
     needs: yaml-check
     uses: ./.github/workflows/custom-workflow.yml
+    with:
+      render-type: 'preview'
 
   spell-check:
     name: Check spelling

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -379,7 +379,7 @@ jobs:
 
   render-preview:
     name: Render preview
-    needs: yaml-check
+    needs: [yaml-check, call-custom-workflow]
     runs-on: ubuntu-latest
     container:
       image: ${{needs.yaml-check.outputs.rendering_docker_image}}

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -32,9 +32,16 @@ jobs:
       rendering_docker_image: "${{ env.RENDERING_DOCKER_IMAGE }}"
       toggle_quiz_check: "${{ env.CHECK_QUIZZES }}"
 
+  call-custom-workflow:
+    name: Custom Workflow
+    needs: yaml-check
+    uses: ./.github/workflows/custom-workflow.yml
+    with:
+      render-type: 'main'
+
   render-bookdown:
     name: Render bookdown
-    needs: yaml-check
+    needs: [yaml-check, call-custom-workflow]
     runs-on: ubuntu-latest
     container:
       image: ${{needs.yaml-check.outputs.rendering_docker_image}}
@@ -85,7 +92,7 @@ jobs:
 
   render-tocless:
     name: Render TOC-less version for Leanpub or Coursera
-    needs: [yaml-check]
+    needs: [yaml-check, call-custom-workflow]
     runs-on: ubuntu-latest
     container:
       image: ${{needs.yaml-check.outputs.rendering_docker_image}}
@@ -122,7 +129,7 @@ jobs:
 
   render-leanpub:
     name: Finish Leanpub prep
-    needs: [yaml-check, render-tocless]
+    needs: [yaml-check, call-custom-workflow, render-tocless]
     runs-on: ubuntu-latest
     container:
       image: jhudsl/ottrpal:main
@@ -187,7 +194,7 @@ jobs:
 
   render-coursera:
     name: Finish Coursera prep
-    needs: [yaml-check, render-tocless]
+    needs: [yaml-check, call-custom-workflow, render-tocless]
     runs-on: ubuntu-latest
     container:
       image: ${{needs.yaml-check.outputs.rendering_docker_image}}


### PR DESCRIPTION
Adds a super simple custom workflow. Based on @cansavvy 's work and the discussion here: https://github.com/jhudsl/AnVIL_Template/pull/64

OTTR should:

- Ignore `custom-workflow.yml`
- Ensure repos downstream can add customization without OTTR syncs overwriting anything.

See the custom-workflow file here https://github.com/jhudsl/AnVIL_Template/pull/64 for an idea of what a custom workflow might entail. 