### PR TITLE
clean and consolidate styling for callout boxes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -299,35 +299,6 @@ div.reflection{
   background-image: url("../assets/box_images/thinking_face.png");
 }
 
-/* old style boxes - keep for backwards compatibility?*/
-
-div.rstudio-tip, div.tip, div.gotcha, div.design, div.hat{
-  border: 4px #aed6d963;
-  border-style: dashed solid;
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
-  background-size: 70px;
-  background-repeat: no-repeat;
-  background-position: 15px center;
-  min-height: 120px;
-  color: #2ea8b3;
-  background-color: #fcfcfc;
-}
-
-div.puzzle, div.fyi, div.demo, div.note {
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
-  background-size: 70px;
-  background-repeat: no-repeat;
-  background-position: 15px center;
-  min-height: 120px;
-  color: #1f5386;
-  background-color: #bed3ec;
-  border: solid 5px #dfedff;
-}
-
 
 /* .book .book-body .page-wrapper .page-inner section.normal is needed
    to override the styles produced by gitbook, which are ridiculously

--- a/assets/style.css
+++ b/assets/style.css
@@ -58,11 +58,11 @@ h1, h2, h3, h4 {
 }
 
 
-.book .book-body .page-wrapper .page-inner section.normal h1, 
-.book .book-body .page-wrapper .page-inner section.normal h2, 
-.book .book-body .page-wrapper .page-inner section.normal h3, 
-.book .book-body .page-wrapper .page-inner section.normal h4, 
-.book .book-body .page-wrapper .page-inner section.normal h5, 
+.book .book-body .page-wrapper .page-inner section.normal h1,
+.book .book-body .page-wrapper .page-inner section.normal h2,
+.book .book-body .page-wrapper .page-inner section.normal h3,
+.book .book-body .page-wrapper .page-inner section.normal h4,
+.book .book-body .page-wrapper .page-inner section.normal h5,
 .book .book-body .page-wrapper .page-inner section.normal h6 {
     margin-top: 2.275em;
     margin-bottom: 1em;
@@ -80,7 +80,7 @@ h1, h2, h3, h4 {
   font-family: 'Lora';
   color: #0b8d96;
 }
-  
+
 
 /*----------DROP CAPS--------------*/
 
@@ -146,7 +146,7 @@ color: #012d72
 }
 
 /* all TOC list items, basically */
-.book .book-summary ul.summary li a, 
+.book .book-summary ul.summary li a,
 .book .book-summary ul.summary li span {
   padding-top: 8px;
   padding-bottom: 8px;
@@ -157,14 +157,14 @@ color: #012d72
 
 .summary a:hover {
   color: #68ace5 !important;
-} 
+}
 
 .book .book-summary ul.summary li.active>a { /*active TOC links*/
   color: #68ace5 !important;
   border-left: solid 4px;
   border-color: #68ace5;
   padding-left: 11px !important;
-} 
+}
 
 
 li.appendix span, li.part span { /* for TOC part names */
@@ -206,7 +206,7 @@ li.appendix span, li.part span { /* for TOC part names */
 }
 
 .summary > li:first-child {
-  height: auto !important; 
+  height: auto !important;
 }
 
 /* --------------Two columns--------------- */
@@ -250,94 +250,56 @@ li.appendix span, li.part span { /* for TOC part names */
 /* Sidebar formating --------------------------------------------*/
 /* from r-pkgs.org*/
 
-
-div.notice{
-  border: 4px #68ace5;
+div.notice, div.warning, div.github, div.dictionary, div.reflection {
   border-style: solid;
   padding: 1em;
   margin: 1em 0;
   padding-left: 100px;
-  background-size: 70px;
-  background-repeat: no-repeat;
-  background-position: 15px center;
   min-height: 120px;
-  background-color: #e8ebee;
+  background-repeat: no-repeat;
 }
 
 div.notice{
+  border: 4px #68ace5;
+  background-size: 70px;
+  background-position: 15px center;
+  background-color: #e8ebee;
   background-image: url("../assets/box_images/note.png");
 }
 
 div.warning{
   border: 4px #e0471c;
-  border-style: solid;
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
   background-size: 70px;
-  background-repeat: no-repeat;
   background-position: 15px center;
-  min-height: 120px;
   background-color: #e8ebee;
-}
-
-div.warning{
   background-image: url("../assets/box_images/warning.png");
 }
 
-
-
 div.github{
   border: 4px #000000;
-  border-style: solid;
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
   background-size: 70px;
-  background-repeat: no-repeat;
   background-position: 15px center;
-  min-height: 120px;
   background-color: #e8ebee;
-}
-
-div.github{
   background-image: url("../assets/box_images/github.png");
 }
 
 div.dictionary{
   border: 4px #68ace5;
-  border-style: solid;
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
   background-size: 70px;
-  background-repeat: no-repeat;
   background-position: 15px center;
-  min-height: 120px;
   background-color: #e8ebee;
-}
-
-div.dictionary{
   background-image: url("../assets/box_images/dictionary.png");
 }
 
-
 div.reflection{
   border: 4px #68ace5;
-  border-style: solid;
-  padding: 1em;
-  margin: 1em 0;
-  padding-left: 100px;
   background-size: 90px;
-  background-repeat: no-repeat;
   background-position: 15px center;
-  min-height: 120px;
   background-color: #e8ebee;
-}
-
-div.reflection{
   background-image: url("../assets/box_images/thinking_face.png");
 }
+
+/* old style boxes - keep for backwards compatibility?*/
 
 div.rstudio-tip, div.tip, div.gotcha, div.design, div.hat{
   border: 4px #aed6d963;
@@ -353,29 +315,6 @@ div.rstudio-tip, div.tip, div.gotcha, div.design, div.hat{
   background-color: #fcfcfc;
 }
 
-
-div.rstudio-tip {
-  background-image: url("../images/divs/rstudio.png");
-}
-
-div.tip {
-  background-image: url("../images/divs/lightbulb.png");
-}
-
-div.gotcha {
-  background-image: url("../images/divs/gotcha_2.png");
-}
-
-div.design {
-  background-image: url("../images/divs/design.png");
-}
-
-div.hat {
-  background-image: url("../images/divs/hat.png");
-}
-
-/* for fancy bookdown cookbook */
-
 div.puzzle, div.fyi, div.demo, div.note {
   padding: 1em;
   margin: 1em 0;
@@ -387,22 +326,6 @@ div.puzzle, div.fyi, div.demo, div.note {
   color: #1f5386;
   background-color: #bed3ec;
   border: solid 5px #dfedff;
-}
-
-div.puzzle {
-  background-image: url("../images/illos/Your-turn.png");
-}
-
-div.fyi {
-  background-image: url("../images/illos/fyi.png");
-}
-
-div.demo {
-  background-image: url("../images/illos/Live-code.png");
-}
-
-div.note {
-  background-image: url("../images/illos/lightbulb2.png");
 }
 
 
@@ -421,12 +344,12 @@ div.note {
   margin-bottom: 0;
 }
 
-iframe { 
-   -moz-transform-origin: top left; 
-   -webkit-transform-origin: top left; 
-   -o-transform-origin: top left; 
-   -ms-transform-origin: top left; 
-   transform-origin: top left; 
+iframe {
+   -moz-transform-origin: top left;
+   -webkit-transform-origin: top left;
+   -o-transform-origin: top left;
+   -ms-transform-origin: top left;
+   transform-origin: top left;
 }
 
 .iframe-container {
@@ -493,14 +416,14 @@ a.anchor {
 }
 
 
-.hasAnchor:hover a.anchor, 
+.hasAnchor:hover a.anchor,
 a.anchor:hover {
   /*visibility: visible;*/
   opacity: 0.6;
 }
 
 /* disable anchors for headers with "no-anchor" class */
-.no-anchor .hasAnchor:hover a.anchor, 
+.no-anchor .hasAnchor:hover a.anchor,
 .no-anchor a.anchor:hover {
   opacity: 0 !important;
 }


### PR DESCRIPTION
I'm working on adding the fancy new callout boxes to AnVIL_Template, and had some suggestions for consolidating the css.  All suggestions, take 'em or leave 'em :)

### Consolidate new style boxes

For the new style boxes, this consolidates the style settings that seem like they should stay consistent across all box types (e.g. spacing and minimum height).  Then the individual box types just specify stuff to do with color and the image.

Specifically, these are shared:
```
  border-style: solid;
  padding: 1em;
  margin: 1em 0;
  padding-left: 100px;
  min-height: 120px;
  background-repeat: no-repeat;
```

And these are specified individually for each box:
```
  border: 4px #68ace5;
  background-size: 70px;
  background-position: 15px center;
  background-color: #e8ebee;
  background-image: url("../assets/box_images/note.png");
```

### Remove broken image references

For the old style boxes, I deleted the references to images since the images don't exist in OTTR_Template.

Question: should we just delete the old style box styles entirely?  I left them in case anyone is using them (AnVIL actually uses the fyi style, but I'll be changing that).  But I think the odds of breaking stuff for anybody at this point are pretty low...wonder if we should just ditch them before too many people start using OTTR.

### Misc
Also it looks like RStudio removed spaces from the ends of some lines, so, there are some meaningless extra whitespace differences...I can try to swap these back if that's annoying.