### PR TITLE
Bump create-issue-from-file action

### DIFF
--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -88,7 +88,7 @@ jobs:
 
       # Issue for what repository settings need to be set
       - name: New Course - Set Repository Settings
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: New Course - Set Repository Settings
           content-filepath: .github/automatic-issues/set-repo-settings.md
@@ -96,7 +96,7 @@ jobs:
 
       # Issue for what needs to be edited
       - name: New Course - Templates to Edit
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: New Course - Templates to Edit
           content-filepath: .github/automatic-issues/templates-to-edit.md
@@ -104,7 +104,7 @@ jobs:
 
       # Issue for how to enroll repo for updates
       - name: New Course - Template Update Enrollment
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: New Course - Template Update Enrollment
           content-filepath: .github/automatic-issues/update-enrollment.md
@@ -112,7 +112,7 @@ jobs:
 
       # Issue for adding a method of feedback
       - name: Reminder - Add a method of user feedback
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: Reminder - Add user feedback method
           content-filepath: .github/automatic-issues/add-feedback-method.md
@@ -128,7 +128,7 @@ jobs:
       # Issue for adding the course to the jhudsl library
       - name: Reminder - Add to jhudsl library
         if: ${{ steps.get_org_name.outputs.org_name == 'jhudsl' }}
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: Reminder - Add to jhudsl library
           content-filepath: .github/automatic-issues/add-to-library.md


### PR DESCRIPTION
The starting course workflow for new repos from template is failing. See example here: https://github.com/jhudsl/test/runs/7751893097?check_suite_focus=true

Easy fix with a version update for this action:

peter-evans/create-issue-from-file@v2.3.2 >> peter-evans/create-issue-from-file@v4