### PR TITLE
Update sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -10,6 +10,7 @@ group:
           send-updates.yml
           test-send-updates.yml
           starting-course.yml
+          release-notes.yml
       - source: .github/ISSUE_TEMPLATE/course-problem-report.md
         dest: .github/ISSUE_TEMPLATE/course-problem-report.md
       - source: .github/ISSUE_TEMPLATE/course-content-add.md
@@ -89,6 +90,7 @@ group:
       dest: .github/workflows/
       exclude: |
         starting-course.yml
+        release-notes.yml
     - source: .github/switch_sync_repo.R
       dest: .github/switch_sync_repo.R
     - source: .github/ISSUE_TEMPLATE/course-problem-report.md


### PR DESCRIPTION
Working on syncing for `AnVIL_Template` - we've got our own version of `release-notes.yml` that we don't want to get clobbered.

Also figured that the main group of repos made directly from `OTTR_Template` don't need the release-notes workflow, so added it to their "exclude" list as well.