### PR TITLE
Remove AnVIL repos from sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -36,9 +36,6 @@ group:
       jhudsl/Informatics_Research_Leadership
       jhudsl/Data_Management_for_Cancer_Research
       jhudsl/Computing_for_Cancer_Informatics
-      jhudsl/AnVIL_Book_Getting_Started
-      jhudsl/AnVIL_Book_Instructor_Guide
-      jhudsl/AnVIL_Book_WDL
       jhudsl/Adv_Reproducibility_in_Cancer_Informatics
       jhudsl/Reproducibility_in_Cancer_Informatics
       jhudsl/Choosing_Genomics_Tools
@@ -48,7 +45,6 @@ group:
       jhudsl/Cancer_Informatics_Data_Visualization
       jhudsl/Cancer_Genome_Informatics
       jhudsl/Cancer-Imaging-Informatics
-      jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL
       datatrail-jhu/DataTrail_Template
       abyzovlab/CNVpytor-course
       opencasestudies/OCS_Guide


### PR DESCRIPTION
This PR removes AnVIL related repos from the downstream sync. These repos will receive updates from https://github.com/jhudsl/AnVIL_Template instead.