### PR TITLE
Update links in automatic issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,17 +22,17 @@
 
 - [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template/blob/main/02-chapter_of_course.Rmd).
 
-- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).
+- [ ] New content/chapter contains learning objectives.
 
 - [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).
 
-- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).
+- [ ] [Spell check runs successfully](https://www.ottrproject.org/customize-robots.html#Spell_checking)).
 
-- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/OTTR_Template/wiki/Using-Docker#adding-packages-to-the-dockerfile).
+- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://www.ottrproject.org/customize-docker.html).
 
-- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).
+- [ ] Images are in the [correct format for rendering](https://www.ottrproject.org/writing_content.html#set-up-images).
 
-- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#accessibility).
+- [ ] Every new image has [alt text and is in a Google Slide](https://www.ottrproject.org/writing_content.html#Accessibility).
 
 - [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.
 

--- a/.github/automatic-issues/add-feedback-method.md
+++ b/.github/automatic-issues/add-feedback-method.md
@@ -1,4 +1,4 @@
 
 To help users report issues or areas of improvement for your course, you should provide a clear method of feedback for your users to route their concerns through.
 
-[See these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Set-up-feedback-method) for suggestions on how to add a feedback method for this course. 
+[Read this chapter from an OTTR-made course about how to obtain user feedback](https://jhudatascience.org/Documentation_and_Usability/obtaining-user-feedback.html).

--- a/.github/automatic-issues/add-to-library.md
+++ b/.github/automatic-issues/add-to-library.md
@@ -1,8 +1,0 @@
-
-\* This is only pertinent to courses in the `jhudsl` organization. 
-
-To help learners find your course, and for it to be tracked in the future, you may want to consider adding the course to the jhudsl course library.
-
-You should not worry about adding the course before it is ready to be made public but this issue is to remind you to do so.
-
-[Follow these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Release-a-course-for-public-viewing) to add this new course to the jhudsl library.

--- a/.github/automatic-issues/git-secrets.md
+++ b/.github/automatic-issues/git-secrets.md
@@ -1,7 +1,7 @@
 
 **Note these steps are only pertinent if you are setting up this course outside of the jhudsl organization**
 
-For more information on these settings see instructions in the [getting started GitHub wiki pages](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-GitHub-secrets).
+For more information on these settings see instructions in the [getting started on ottrproject.org](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token).
 
 It's important that these are set up and named exactly what they are below in order for Github actions to work correctly.
 

--- a/.github/automatic-issues/git-secrets.md
+++ b/.github/automatic-issues/git-secrets.md
@@ -9,6 +9,6 @@ To set up these repository secrets, on your repository's main Github page, go to
 
 - [ ] Set `GH_PAT`
 `Name`:  `GH_PAT`
-`value`: A personal access token [following these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#6-set-up-your-github-personal-access-token).
+`value`: A personal access token [following these instructions](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token).
 Underneath `Select scopes`, check both `repo` and `workflow`.
 Then copy the PAT and save as the value.

--- a/.github/automatic-issues/git-secrets.md
+++ b/.github/automatic-issues/git-secrets.md
@@ -9,6 +9,6 @@ To set up these repository secrets, on your repository's main Github page, go to
 
 - [ ] Set `GH_PAT`
 `Name`:  `GH_PAT`
-`value`: A personal access token [following these instructions](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token).
+`value`: A personal access token [following these instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token).
 Underneath `Select scopes`, check both `repo` and `workflow`.
 Then copy the PAT and save as the value.

--- a/.github/automatic-issues/images-checklist.md
+++ b/.github/automatic-issues/images-checklist.md
@@ -1,20 +1,20 @@
 
 Use this checklist to make sure your slides and images are set up correctly!
 
-See [Setting Up Images and Graphics](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics) for more info!
+See [Setting Up Images and Graphics](https://www.ottrproject.org/writing_content.html#set-up-images) for more info!
 
-- [ ] Create your [course's main Google Slides](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics)
+- [ ] Create your course's main Google Slides.
 
-- [ ] The slides use the [appropriate template](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics).
+- [ ] The slides use the appropriate template.
 
 - [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.
 
 - [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
 You can check this using [Color Oracle](https://colororacle.org/).
 
-- [ ] Every image is [inserted into the text](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text) using one of these options: `ottrpal::include_slide()`, `knitr::include_image()`, or this format: `<img src="blah.png" alt="SOMETHING">`.
+- [ ] Every image is inserted into the text using one of these options: `ottrpal::include_slide()`, `knitr::include_image()`, or this format: `<img src="blah.png" alt="SOMETHING">`.
 
-- [ ] Every image has [alternative text added to it](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).
+- [ ] Every image has alternative text added to it.
 
 - [ ] The beginning of each Rmd contains this chunk so the images are saved in the correct spot:
 

--- a/.github/automatic-issues/set-repo-settings.md
+++ b/.github/automatic-issues/set-repo-settings.md
@@ -1,9 +1,9 @@
 
-For more information on these settings see instructions in the [getting started GitHub wiki pages](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course).
+For more information on these settings see instructions in the [Starting a new OTTR course](https://www.ottrproject.org/getting_started.html#starting-a-new-ottr-course).
 
 - [ ] This course repository is set to `public`.
-- [ ] [Add the `jhudsl-robot` as a collaborator to your repository.](https://github.com/jhudsl/OTTR_Template/wiki/Setting-up-your-repository-settings#add-jhudsl-robot-as-a-collaborator).
-- [ ] [GH_PAT has been set up as a GitHub secret](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#6-set-up-your-github-personal-access-token)
+- [ ] [Add the `jhudsl-robot` as a collaborator to your repository.](https://www.ottrproject.org/getting_started.html#5_Add_jhudsl-robot_as_a_collaborator).
+- [ ] [GH_PAT has been set up as a GitHub secret](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token)
 
 - [ ] GitHub pages is turned on
   - [ ] Go to `Settings` > `Pages`. Underneath `Source`, choose `main` for the branch and select the `docs` folder. Then click `Save`.  

--- a/.github/automatic-issues/set-repo-settings.md
+++ b/.github/automatic-issues/set-repo-settings.md
@@ -1,19 +1,18 @@
 
-For more information on these settings see instructions in the [Starting a new OTTR course](https://www.ottrproject.org/getting_started.html#starting-a-new-ottr-course).
+For more information on these settings see instructions in [Starting a new OTTR course](https://www.ottrproject.org/getting_started.html#starting-a-new-ottr-course).
 
 - [ ] This course repository is set to `public`.
 - [ ] [Add the `jhudsl-robot` as a collaborator to your repository.](https://www.ottrproject.org/getting_started.html#5_Add_jhudsl-robot_as_a_collaborator).
-- [ ] [GH_PAT has been set up as a GitHub secret](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token)
 
-- [ ] GitHub pages is turned on
-  - [ ] Go to `Settings` > `Pages`. Underneath `Source`, choose `main` for the branch and select the `docs` folder. Then click `Save`.  
-  - [ ] Check `Enforce HTTPS`.
-
-- [ ] [Github secret `GH_PAT` has been set](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#6-set-up-your-github-personal-access-token)
+- [ ] [Github secret `GH_PAT` has been set](https://www.ottrproject.org/getting_started.html#6_Set_up_your_GitHub_personal_access_token)
   `Name`:  `GH_PAT`
   `value`: A personal access token [following these instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token).
   Underneath `Select scopes`, check both `repo` and `workflow`.
   Then copy the PAT and save as the value.
+  
+- [ ] GitHub pages is turned on
+  - [ ] Go to `Settings` > `Pages`. Underneath `Source`, choose `main` for the branch and select the `docs` folder. Then click `Save`.  
+  - [ ] Check `Enforce HTTPS`.
 
 - [ ] [Set branch protections settings](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#9-set-up-branch-rules)
   - [ ] `main` branch has been set up:

--- a/.github/automatic-issues/set-repo-settings.md
+++ b/.github/automatic-issues/set-repo-settings.md
@@ -14,7 +14,7 @@ For more information on these settings see instructions in [Starting a new OTTR 
   - [ ] Go to `Settings` > `Pages`. Underneath `Source`, choose `main` for the branch and select the `docs` folder. Then click `Save`.  
   - [ ] Check `Enforce HTTPS`.
 
-- [ ] [Set branch protections settings](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#9-set-up-branch-rules)
+- [ ] [Set branch protections settings](https://www.ottrproject.org/getting_started.html#8_Set_up_branch_rules)
   - [ ] `main` branch has been set up:
     - [ ] `Require pull request reviews before merging` box is checked.
     - [ ] `Require status checks to pass before merging` box is checked.

--- a/.github/automatic-issues/set-repo-settings.md
+++ b/.github/automatic-issues/set-repo-settings.md
@@ -21,4 +21,4 @@ For more information on these settings see instructions in [Starting a new OTTR 
       - [ ] Underneath that `Require branches to be up to date before merging` box is checked.
   - [ ] Click `Save` at the bottom of the page!
 
-- [ ] [Customize GitHub actions](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots) for what you will need in this course.
+- [ ] [Customize GitHub actions](https://www.ottrproject.org/customize-robots.html) for what you will need in this course.

--- a/.github/automatic-issues/templates-to-edit.md
+++ b/.github/automatic-issues/templates-to-edit.md
@@ -1,5 +1,5 @@
 
-[Follow the Wiki instructions here](https://github.com/jhudsl/OTTR_Template/wiki/Start-editing-your-course) for details on how to complete the items in this issue.
+[Follow the instructions here in ottrproject.org](https://www.ottrproject.org/writing_content.html) for details on how to start editing your OTTR course
 
 The following files need to be edited to get this new course started!
 

--- a/.github/automatic-issues/templates-to-edit.md
+++ b/.github/automatic-issues/templates-to-edit.md
@@ -12,17 +12,17 @@ The following files need to be edited to get this new course started!
 
 ### Files that need to be edited upon adding each new chapter (including upon creating a new course):
 
-- [ ] `_bookdown.yml` - The list of Rmd files that need to be rendered needs to be updated. See [instructions](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).
-- [ ] `book.bib` - any citations need to be added. See [instructions](https://github.com/jhudsl/OTTR_Template/wiki/Citations).
+- [ ] `_bookdown.yml` - The list of Rmd files that need to be rendered needs to be updated. See [instructions](https://www.ottrproject.org/examples.html#publishing-with-bookdown).
+- [ ] `book.bib` - any citations need to be added. See [instructions](https://www.ottrproject.org/more_features.html#citing-sources).
 
 ### Picking a style
 
-See more [about customizing style on this page in the guide](https://github.com/jhudsl/OTTR_Template/wiki/Change-Title-&-Customize-style).
+See more [about customizing style on this page in the guide](https://www.ottrproject.org/customize-style.html).
 By default this course template will use the jhudsl data science lab style. However, you can customize and switch this to another style set.
 
 #### Using a style set
 
-[Read more about the style sets here](https://github.com/jhudsl/OTTR_Template/wiki/Change-Title-&-Customize-style#using-a-style-set).
+[Read more about the style sets here](https://www.ottrproject.org/customize-style.html#Using_a_style_set).
 
 - [ ] On a new branch, copy the `style-sets/<set-name>/index.Rmd` and `style-sets/<set-name>/_output.yml` to the top of the repository to overwrite the default `index.Rmd` and `_output.yml`.
 - [ ] Copy over all the files in the `style-sets/<set-name>/copy-to-assets` to the `assets` folder in the top of the repository.
@@ -30,5 +30,5 @@ By default this course template will use the jhudsl data science lab style. Howe
 
 ### Files that need to be edited upon adding new packages that the book's code uses:
 
-- `docker/Dockerfile` needs to have the new package added so it will be installed. See [instructions](https://github.com/jhudsl/OTTR_Template/wiki/Using-Docker#starting-a-new-docker-image).
+- `docker/Dockerfile` needs to have the new package added so it will be installed. See [instructions](https://www.ottrproject.org/customize-docker.html).
 - The code chunk in `index.Rmd` should be edited to add the new package.

--- a/.github/automatic-issues/templates-to-edit.md
+++ b/.github/automatic-issues/templates-to-edit.md
@@ -26,7 +26,7 @@ By default this course template will use the jhudsl data science lab style. Howe
 
 - [ ] On a new branch, copy the `style-sets/<set-name>/index.Rmd` and `style-sets/<set-name>/_output.yml` to the top of the repository to overwrite the default `index.Rmd` and `_output.yml`.
 - [ ] Copy over all the files in the `style-sets/<set-name>/copy-to-assets` to the `assets` folder in the top of the repository.
-- [ ] [Create a pull request](https://github.com/jhudsl/OTTR_Template/wiki/Start-editing-your-course#getting-started-with-the-github-workflow) with these changes, and double check the rendered preview to make sure that the style is what you are looking for.
+- [ ] [Create a pull request](https://www.ottrproject.org/writing_content.html#Open_a_pull_request) with these changes, and double check the rendered preview to make sure that the style is what you are looking for.
 
 ### Files that need to be edited upon adding new packages that the book's code uses:
 

--- a/.github/automatic-issues/update-enrollment.md
+++ b/.github/automatic-issues/update-enrollment.md
@@ -4,6 +4,6 @@ We are working on adding more features and smoothing out bugs as we go.
 
 If you want to receive updates from the original template to your course template, you will need to enroll this repository to the template updates by adding it to the `sync.yml` file.
 
-- [ ] [Follow these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#9-enroll-your-repository-for-ottr-updates) to enroll your course repository to receive these updates.
+- [ ] [Follow these instructions](https://www.ottrproject.org/getting_started.html#9_Enroll_your_repository_for_OTTR_updates) to enroll your course repository to receive these updates.
 
-- [ ] [Ensure that you have followed these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#5-add-jhudsl-robot-as-a-collaborator) to add the `jhudsl-robot` as a collaborator to your repository.
+- [ ] [Ensure that you have followed these instructions](https://www.ottrproject.org/getting_started.html#5_Add_jhudsl-robot_as_a_collaborator) to add the `jhudsl-robot` as a collaborator to your repository.

--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -1,7 +1,7 @@
 
 # A new chapter
 
-If you haven't yet read the getting started Wiki pages; [start there](https://github.com/jhudsl/OTTR_Template/wiki/Getting-started).
+If you haven't yet read the getting started Wiki pages; [start there](https://www.ottrproject.org/getting_started.html).
 
 To see the rendered version of this chapter and the rest of the template, see here: https://jhudatascience.org/OTTR_Template/.
 
@@ -82,7 +82,7 @@ But if you have the slide or some other image locally downloaded you can also us
 ## Video examples
 You may also want to embed videos in your course. If alternatively, you just want to include a link you can do so like this:
 
-Check out this [link to a video](https://www.youtube.com/embed/VOCYL-FNbr0) using markdown syntax. 
+Check out this [link to a video](https://www.youtube.com/embed/VOCYL-FNbr0) using markdown syntax.
 
 ### Using `knitr`
 
@@ -150,7 +150,7 @@ In text, we can put citations like this @rmarkdown2021.
 
 ## Stylized boxes
 
-Occasionally, you might find it useful to emphasize a particular piece of information. To help you do so, we have provided css code and images (no need for you to worry about that!) to create the following stylized boxes. 
+Occasionally, you might find it useful to emphasize a particular piece of information. To help you do so, we have provided css code and images (no need for you to worry about that!) to create the following stylized boxes.
 
 You can use these boxes in your course with either of two options: using HTML code or Pandoc syntax.
 

--- a/About.Rmd
+++ b/About.Rmd
@@ -1,7 +1,7 @@
 
 # About the Authors {-}
 
-These credits are based on our [course contributors table guidelines](https://github.com/jhudsl/OTTR_Template/wiki/How-to-give-credits).
+These credits are based on our [course contributors table guidelines](https://www.ottrproject.org/more_features.html#giving-credits-to-contributors).
 
 &nbsp;
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ _This template and guide helps you_:
   - [Leanpub](https://leanpub.com/bookstore?type=course)
   - [Bookdown](https://bookdown.org/)
   - [Coursera](https://www.coursera.org/)
-- Have [Github action robots](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots) do your repetitive tasks like spell check and re-rendering.
+- Have [Github action robots](https://www.ottrproject.org/customize-robots.html) do your repetitive tasks like spell check and re-rendering.
 - Use [automagic conversion](https://github.com/jhudsl/ottrpal) to ease the lift of prepping the material for different platforms' formats.
-- Use [our Docker image](https://hub.docker.com/repository/docker/jhudsl/course_template) for consistency across authors as well as to help you [avoid dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
+- Use [our Docker image](https://hub.docker.com/repository/docker/jhudsl/base_ottr) for consistency across authors as well as to help you [avoid dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
 [See the OTTR pre-print here!](https://arxiv.org/abs/2203.07083)
 


### PR DESCRIPTION
I'm starting a new book, and realized these still link to the wiki.  I'll update the links to point to ottrproject.org as I work through the steps.

- Updates links in the automatic issue `set-repo-settings`
- Instructions to set up GH_PAT were listed twice, so I removed the less detailed one.
- Updates links in automatic issue `update-enrollment`
- Updates (most) links in automatic issue `templates-to-edit`


