### PR TITLE
switch the name and refs of course_template to base_ottr

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: jhudsl/course_template
+          tags: jhudsl/base_ottr
 
       # Login to Dockerhub
       - name: Login to DockerHub
@@ -74,5 +74,5 @@ jobs:
       - name: Push Docker image if manual trigger set to true
         if: ${{ github.event.inputs.dockerhubpush != 'false' }}
         run: |
-          docker tag jhudsl/course_template:latest jhudsl/course_template:$github.event.inputs.tag
-          docker push jhudsl/course_template:$github.event.inputs.tag
+          docker tag jhudsl/base_ottr:latest jhudsl/base_ottr:$github.event.inputs.tag
+          docker push jhudsl/base_ottr:$github.event.inputs.tag

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{needs.yaml-check.outputs.toggle_style_code == 'yes'}}
     container:
-      image: jhudsl/course_template:main
+      image: jhudsl/base_ottr:main
 
     steps:
       - name: Checkout files
@@ -274,4 +274,4 @@ jobs:
           load: true
           context: docker
           file: docker/Dockerfile
-          tags: jhudsl/course_template
+          tags: jhudsl/base_ottr

--- a/.github/workflows/test-send-updates.yml
+++ b/.github/workflows/test-send-updates.yml
@@ -14,7 +14,7 @@ jobs:
   test-sync:
     runs-on: ubuntu-latest
     container:
-      image: jhudsl/course_template:main
+      image: jhudsl/base_ottr:main
 
     steps:
       - name: Checkout Repository

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -16,3 +16,8 @@ The course is intended for ...
 ## Curriculum  
 
 The course covers...
+
+
+```{r}
+devtools::session_info()
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _This template and guide helps you_:
   - [Coursera](https://www.coursera.org/)
 - Have [Github action robots](https://github.com/jhudsl/OTTR_Template/wiki/How-to-set-up-and-customize-GitHub-actions-robots) do your repetitive tasks like spell check and re-rendering.
 - Use [automagic conversion](https://github.com/jhudsl/ottrpal) to ease the lift of prepping the material for different platforms' formats.
-- Use [our Docker image](https://hub.docker.com/repository/docker/jhudsl/course_template) for consistency across authors as well as to help you [avoid dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
+- Use [our Docker image](https://hub.docker.com/repository/docker/jhudsl/base_ottr) for consistency across authors as well as to help you [avoid dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
 
 [See the OTTR pre-print here!](https://arxiv.org/abs/2203.07083)
 

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -20,5 +20,5 @@ render-leanpub: no
 render-coursera: no
 
 # What docker image should be used for rendering?
-# The default is jhudsl/course_template:main
-rendering-docker-image: 'jhudsl/course_template:main'
+# The default is jhudsl/base_ottr:main
+rendering-docker-image: 'jhudsl/base_ottr:main'

--- a/docs/coursera/resources/Dockerfile
+++ b/docs/coursera/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM jhudsl/course_template
+FROM jhudsl/base_ottr
 LABEL maintainer="your_email.com"
 
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################

--- a/docs/no_toc/resources/TEMPLATE_Dockerfile
+++ b/docs/no_toc/resources/TEMPLATE_Dockerfile
@@ -1,4 +1,4 @@
-FROM jhudsl/course_template
+FROM jhudsl/base_ottr
 LABEL maintainer="your_email.com"
 
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM jhudsl/course_template
+FROM jhudsl/base_ottr
 LABEL maintainer="your_email.com"
 
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################

--- a/resources/TEMPLATE_Dockerfile
+++ b/resources/TEMPLATE_Dockerfile
@@ -1,4 +1,4 @@
-FROM jhudsl/course_template:main
+FROM jhudsl/base_ottr:main
 LABEL maintainer="your_email.com"
 
 #################### EXAMPLES OF INSTALLING PACKAGES ###########################


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I've been meaning to do this for awhile. I switched the name of course_template to base_ottr in dockerhub but need to update it everywhere else. 

First we need to test that it actually runs appropriately. Note that the dockers for ottr are stored here now: https://github.com/jhudsl/ottr_docker
