### PR TITLE
Have transfer-rendered-files.yml transfer the _bookdown.yml file

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -79,6 +79,9 @@ jobs:
           # Copy over images folder
           svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
 
+          # Copy over _bookdown.yml 
+          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

Parallel change to https://github.com/fhdsl/FH_Cluster_Guide/pull/40 as a result of this error: https://github.com/fhdsl/FH_Cluster_Guide_Quizzes/actions/runs/3198705156/jobs/5223572231

Render leanpub on FH_Cluster_Guide_Quizzes is not happening because of an error that the _bookdown.yml file is not there: 

So this is to make sure that file gets there so the render_leanpub happens and manuscript/ will be made and Leanpub can be published from that. 

