### PR TITLE
New tab target

### DIFF
--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -124,6 +124,10 @@ Yet again you can use a link to a website like so:
 
 [A Website](https://yihui.org)
 
+You might want to have users open a website in a new tab by default, especially if they need to reference both the course and a resource at once.
+
+[A Website](https://yihui.org){target="_blank"}
+
 Or, you can embed some websites.
 
 ### Using `knitr`


### PR DESCRIPTION
### Purpose/implementation Section

Adding instructions in case the author wants to open a link in a new tab by default. Seems to be some buggy behavior with Leanpub opening links without specifying open in a new tab (with right click).