### PR TITLE
update sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -29,6 +29,7 @@ group:
       jhudsl/Documentation_and_Usability
       jhudsl/Informatics_Research_Leadership
       jhudsl/Data_Management_for_Cancer_Research
+      jhudsl/Ethical_Data_Handling_for_Cancer_Research
       jhudsl/Computing_for_Cancer_Informatics
       jhudsl/Adv_Reproducibility_in_Cancer_Informatics
       jhudsl/Reproducibility_in_Cancer_Informatics


### PR DESCRIPTION
moved the ethical info to a new course that was data management so I need to add this again

