### PR TITLE
Update sync.yml for AnVIL css update

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -97,6 +97,8 @@ group:
     - source: assets/box_images/
       dest: assets/box_images/
     - source: assets/style.css
-      dest: assets/AnVIL_style/style.css
+      dest: assets/style.css
+    - source: assets/toc_close.css
+      dest: assets/toc_close.css
     repos: |
       jhudsl/AnVIL_Template


### PR DESCRIPTION
Updating the sync so that https://github.com/jhudsl/AnVIL_Template can receive the style files. 

The way the files is structured is now synonymous across https://github.com/jhudsl/AnVIL_Template and this repo.