### PR TITLE
make book txt -- add to config file as an option

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -29,6 +29,7 @@ jobs:
       toggle_bookdown: "${{ env.RENDER_BOOKDOWN }}"
       toggle_coursera: "${{ env.RENDER_COURSERA }}"
       toggle_leanpub: "${{ env.RENDER_LEANPUB }}"
+      make_book_txt: "${{ env.MAKE_BOOK_TXT }}"
       rendering_docker_image: "${{ env.RENDERING_DOCKER_IMAGE }}"
       toggle_quiz_check: "${{ env.CHECK_QUIZZES }}"
 
@@ -163,7 +164,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = TRUE, \
+            make_book_txt = ${{needs.yaml-check.outputs.make_book_txt}}, \
             quiz_dir = NULL)"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -172,7 +173,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = TRUE)"
+            make_book_txt = ${{needs.yaml-check.outputs.make_book_txt}})"
 
       # Commit the rendered Leanpub files
       - name: Commit rendered Leanpub files

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -164,7 +164,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = as.logical(${{needs.yaml-check.outputs.make_book_txt}}), \
+            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt}}'), \
             quiz_dir = NULL)"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -173,7 +173,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = as.logical(${{needs.yaml-check.outputs.make_book_txt}}))"
+            make_book_txt = as.logical('${{needs.yaml-check.outputs.make_book_txt}}'))"
 
       # Commit the rendered Leanpub files
       - name: Commit rendered Leanpub files

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -164,7 +164,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = ${{needs.yaml-check.outputs.make_book_txt}}, \
+            make_book_txt = as.logical(${{needs.yaml-check.outputs.make_book_txt}}), \
             quiz_dir = NULL)"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -173,7 +173,7 @@ jobs:
           Rscript -e "ottrpal::bookdown_to_embed_leanpub(
             render = FALSE, \
             chapt_img_key = 'resources/chapt_screen_images/chapter_urls.tsv', \
-            make_book_txt = ${{needs.yaml-check.outputs.make_book_txt}})"
+            make_book_txt = as.logical(${{needs.yaml-check.outputs.make_book_txt}}))"
 
       # Commit the rendered Leanpub files
       - name: Commit rendered Leanpub files

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -19,6 +19,10 @@ render-bookdown: yes
 render-leanpub: yes
 render-coursera: no
 
+## Automate the creation of Book.txt file? TRUE/FALSE?
+## This is only relevant if render-leanpub is yes, otherwise it will be ignored
+make-book-txt: TRUE
+
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main
 rendering-docker-image: 'jhudsl/base_ottr:main'


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
It's been brought to my attention that if you'd like to make your own Book.txt file manually (as opposed to the automatic creation of Book.txt as is default) this is not intuitive to set up. 

So I'm adding this as an option in the config_automation.yml file. 


I'll also need to file an appropriate update to ottrproject.org if this works fine. 

#### What was your approach?

I added the option to the config_automation.yml file and then carried that option through in render-all.yml 

### Associated documentation PR: 

https://github.com/jhudsl/ottr-website/pull/36