### PR TITLE
Make old manuscript files *actually* delete

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -139,6 +139,7 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           git config --local user.email "itcrtrainingnetwork@gmail.com"
           git config --local user.name "jhudsl-robot"
 
@@ -186,8 +187,7 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
-          git push origin main || echo "No changes to push"
+          git push --force origin main || echo "No changes to push"
 
   render-coursera:
     name: Finish Coursera prep

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Login as jhudsl-robot
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+          git config --global user.email "itcrtrainingnetwork@gmail.com"
+          git config --global user.name "jhudsl-robot"
 
       # Create screenshots
       - name: Run the screenshot creation
@@ -187,6 +187,7 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
+          git fetch 
           git push --force origin main || echo "No changes to push"
 
   render-coursera:
@@ -206,8 +207,9 @@ jobs:
 
       - name: Login as jhudsl-robot
         run: |
-          git config --local user.email "itcrtrainingnetwork@gmail.com"
-          git config --local user.name "jhudsl-robot"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global user.email "itcrtrainingnetwork@gmail.com"
+          git config --global user.name "jhudsl-robot"
 
       # Run Coursera version
       - name: Convert Leanpub quizzes to Coursera

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -187,8 +187,7 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
-          git fetch 
-          git push --force origin main || echo "No changes to push"
+          git push --force --set-upstream origin main || echo "No changes to push"
 
   render-coursera:
     name: Finish Coursera prep
@@ -227,5 +226,4 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Coursera quizzes' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
-          git push origin main || echo "No changes to push"
+          git push --force --set-upstream origin main || echo "No changes to push"

--- a/manuscript/2-old-version-chapter.md
+++ b/manuscript/2-old-version-chapter.md
@@ -1,0 +1,7 @@
+# 2 A new chapter
+ 
+{type: iframe, title:2 A new chapter, width:800, height:600, poster:resources/chapt_screen_images/a-new-chapter.png}
+![](https://jhudatascience.org/OTTR_Template/no_toc/a-new-chapter.html)
+ 
+
+ 


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
Despite the `rm -rf manuscript` command, old files in the manuscript folder still remain (see the two 2- files in this example: https://github.com/griffithlab/CIVIC_SVI_Course/tree/main/manuscript). 


#### What was your approach?
I think in this instance we actually needed a force push to make sure old files in the manuscript folder are not kept. 

To test this, I'm adding a dummy file: `manuscript/2-old-version-chapter.md`. This dummy file should be deleted if the changes to `render-all.yml` are correct. 