### PR TITLE
when starting course, replace README

### DIFF
--- a/.github/course_README_template.md
+++ b/.github/course_README_template.md
@@ -1,0 +1,24 @@
+# {Course Name}
+
+This course was created from [this GitHub template](https://github.com/jhudsl/OTTR_Template).
+
+You can see the rendered course material here: {Link to rendered bookdown and/or to the Leanpub.}
+
+If you would like to contribute to this course material, take a look at the [OTTR documentation](https://www.ottrproject.org/).
+
+## About this course
+
+This course introduces {info on what this course introduces}
+
+## Learning Objectives
+
+This course will teach learners to:  
+
+- {You can use https://www.bobpikegroup.com/trainer-blog/5-steps-to-writing-clear-and-measurable-learning-objectives to define some learning objectives here}
+- {More learning objectives}
+
+## Encountering problems?
+
+If you are encountering any problems with this course, please file a GitHub issue or contact us at {Some email or web address with a contact form}.
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All materials in this course are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a> unless noted otherwise.

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Cleanup
         run: |
           # Cleanup
+          mv .github/course_README_template.md README.md
           rm -rf \
             .github/workflows/report-maker.yml \
             .github/workflows/send-updates.yml \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<!--Delete this section below upon using the template-->
-
 ## Open-source Tools for Training Resources - OTTR
 
 Go to [ottrproject.org](https://www.ottrproject.org/) to get started! :tada:
@@ -33,31 +31,3 @@ _This template and guide helps you_:
 - Please take a look at the [code of conduct](./code_of_conduct.md).
 - If you encounter any problems or have ideas for improvements to this template repository or this getting started guide, please [file an issue here](https://github.com/jhudsl/OTTR_Template/issues/new/choose)! Your feedback is very much appreciated.
 
-<!--Delete everything above this line upon using the template-->
-
-# {Course Name}
-
-[![Render Bookdown and Coursera](https://github.com/jhudsl/OTTR_Template/actions/workflows/render-all.yml/badge.svg)](https://github.com/jhudsl/OTTR_Template/actions/workflows/render-all.yml)
-
-This course was created from [this GitHub template](https://github.com/jhudsl/OTTR_Template).
-
-You can see the rendered course material here: {Link to rendered bookdown and/or to the Leanpub.}
-
-If you would like to contribute to this course material, take a look at the [getting started GitHub wiki pages](https://github.com/jhudsl/OTTR_Template/wiki).
-
-## About this course
-
-This course introduces {info on what this course introduces}
-
-## Learning Objectives
-
-This course will teach learners to:  
-
-- {You can use https://www.bobpikegroup.com/trainer-blog/5-steps-to-writing-clear-and-measurable-learning-objectives to define some learning objectives here}
-- {More learning objectives}
-
-## Encountering problems?
-
-If you are encountering any problems with this course, please file a GitHub issue or contact us at {Some email or web address with a contact form}.
-
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All materials in this course are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a> unless noted otherwise.


### PR DESCRIPTION
Currently the README is doing double duty - describing OTTR_Template and trying to serve as a reasonable starting point for a README for a course.

I've been working on a C-MOOR branded copy of OTTR_Template, and thought it would be useful to automatically replace the README when starting a course, so that those two concerns can be split up. 

This PR

- adds a `course_README_template.md` to hold the starting point for a course's README
- updates `starting-course.yml` to replace `README.md` with `course_README_template.md`
- moves the course-related content from the existing `README.md` into `course_README_template.md`

@cansavvy If you want to make changes to this PR, go for it - I'm handing it off to you.  I thought you might have other changes you would want to make to the README content, now that's being split up.  I just took the existing content and distributed it between the two files (and updated the link to point to ottrproject.org).