### PR TITLE
Fix transfer quiz repo files

### DIFF
--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -42,22 +42,23 @@ jobs:
     if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes' || needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
 
     steps:
+      - name: Checkout from Bookdown Repo
+        uses: actions/checkout@v4
+        with:
+          path: bookdown
+          token: ${{ secrets.GH_PAT }}
+    
       - name: Run git repo check
         id: git_repo_check
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          sudo apt-get install subversion
-
           # What's the Quizzes repository's name?
           QUIZ_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | sed "s/_Template/ /g" | awk '{print $1"_Quizzes"}')
           echo $QUIZ_REPO
 
-          # Get repo check script
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
-
           # Run repo check script
-          results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
+          results=$(Rscript --vanilla bookdown/scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
           echo $QUIZ_REPO exists: $results
 
           echo "git_results=$results" >> $GITHUB_OUTPUT
@@ -67,6 +68,7 @@ jobs:
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v4
         with:
+          path: quizzes
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
 
@@ -76,17 +78,19 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          # Copy over images folder
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
-
-          # Copy over _bookdown.yml
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          # Copy over images folder (from bookdown to quizzes repo)
+          mkdir -p quizzes/resources/chapt_screen_images
+          cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
+          
+          # Copy over _bookdown.yml (from bookdown to quizzes repo)
+          cp bookdown/_bookdown.yml quizzes/_bookdown.yml
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
+          path: quizzes # Must create the PR in the Quizzes Repo
           token: ${{ secrets.GH_PAT }}
           commit-message: Copy files from Bookdown repository
           signoff: false


### PR DESCRIPTION
### What's Up

Noticed the `transfer-rendered-files.yml` workflow was failing over at https://github.com/fhdsl/NIH_Data_Sharing.

Did a little digging and from what I understand, GitHub doesn't want us to download individual files using either `git archive` or `svn export` for security reasons. 

This solution:
- leverages the `path:` arg, which allows you to checkout multiple repos using `checkout`
- does some good ole' `cp` and `mkdir` to transfer stuff from the bookdown repo to the quizzes repo
- gets rid of the `svn` dependency

Tested over here: https://github.com/fhdsl/NIH_Data_Sharing/pull/117
Successful PR here: https://github.com/fhdsl/NIH_Data_Sharing_Quizzes/pull/3

### Screenshots for your enjoyment 
Workflow log, this error is not just that the link is wrong -- even with a viable link it won't download
![Screenshot 2024-02-16 at 10 21 29 AM](https://github.com/jhudsl/OTTR_Template/assets/15618412/7bf0b14c-6568-47f4-b02c-74a5bd4f0f3a)
GitHub not being helpful
![Screenshot 2024-02-16 at 12 18 46 PM](https://github.com/jhudsl/OTTR_Template/assets/15618412/7f37c163-def4-457b-9c33-545f116418da)
