### PR TITLE
Ensure Coursera quizzes are rendered

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -229,12 +229,16 @@ jobs:
         run: Rscript -e "ottrpal::convert_coursera_quizzes()"
 
       # Commit the rendered bookdown files
+      # Only commit coursera quizzes if the directory is present
       - name: Commit rendered Coursera files
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
           git fetch origin
+          if [ -d 'coursera_quizzes' ]; then
+            git add --force coursera_quizzes/*
+          fi
           git add --force manuscript/*
           git add --force resources/*
           git add --force docs/*

--- a/.github/workflows/transfer-rendered-files.yml
+++ b/.github/workflows/transfer-rendered-files.yml
@@ -42,22 +42,23 @@ jobs:
     if: ${{needs.yaml-check.outputs.toggle_coursera == 'yes' || needs.yaml-check.outputs.toggle_leanpub == 'yes'}}
 
     steps:
+      - name: Checkout from Bookdown Repo
+        uses: actions/checkout@v4
+        with:
+          path: bookdown
+          token: ${{ secrets.GH_PAT }}
+    
       - name: Run git repo check
         id: git_repo_check
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          sudo apt-get install subversion
-
           # What's the Quizzes repository's name?
           QUIZ_REPO=$(echo ${GITHUB_REPOSITORY} | sed "s/_Bookdown/ /g" | sed "s/_Template/ /g" | awk '{print $1"_Quizzes"}')
           echo $QUIZ_REPO
 
-          # Get repo check script
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/scripts/git_repo_check.R git_repo_check.R
-
           # Run repo check script
-          results=$(Rscript --vanilla git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
+          results=$(Rscript --vanilla bookdown/scripts/git_repo_check.R --repo "$GITHUB_REPOSITORY" --git_pat "$GH_PAT")
           echo $QUIZ_REPO exists: $results
 
           echo "git_results=$results" >> $GITHUB_OUTPUT
@@ -67,6 +68,7 @@ jobs:
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: actions/checkout@v4
         with:
+          path: quizzes
           repository: ${{ steps.git_repo_check.outputs.leanpub_repo }}
           token: ${{ secrets.GH_PAT }}
 
@@ -76,17 +78,19 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          # Copy over images folder
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/resources/chapt_screen_images resources/chapt_screen_images
-
-          # Copy over _bookdown.yml
-          svn export --force https://github.com/${GITHUB_REPOSITORY}.git/branches/${GITHUB_REF#refs/heads/}/_bookdown.yml _bookdown.yml
+          # Copy over images folder (from bookdown to quizzes repo)
+          mkdir -p quizzes/resources/chapt_screen_images
+          cp bookdown/resources/chapt_screen_images/* quizzes/resources/chapt_screen_images
+          
+          # Copy over _bookdown.yml (from bookdown to quizzes repo)
+          cp bookdown/_bookdown.yml quizzes/_bookdown.yml
 
       - name: Create PR with resources files
         if: ${{ steps.git_repo_check.outputs.git_results == 'TRUE' }}
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:
+          path: quizzes # Must create the PR in the Quizzes Repo
           token: ${{ secrets.GH_PAT }}
           commit-message: Copy files from Bookdown repository
           signoff: false


### PR DESCRIPTION
Coursera style quizzes aren't getting committed.

Noticed this over at https://github.com/fhdsl/NIH_Data_Sharing, and looks like @carriewright11 also noticed this at #700

Added an if then just in case, so it won't break if there are no quizzes and no directory.

Tested and merged here: https://github.com/fhdsl/NIH_Data_Sharing/blob/d8d1734adab3dfcb4ed16205b5dc1f0b646e7228/.github/workflows/render-all.yml#L239

Resolves #700 