### PR TITLE
Comprehensive preview add

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -160,6 +160,9 @@ jobs:
           echo Toc-less status ${{steps.tocless.outcome}}
           exit 1
 
+      - name: Website preview for download
+        run: zip website-preview.zip docs/* -r
+
       # Commit the rendered bookdown files
       - name: Commit rendered bookdown files to preview branch
         id: commit
@@ -188,6 +191,8 @@ jobs:
           bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/index.html")
           tocless_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/docs/no_toc/index.html")
           docx_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/docs/$course_name.docx")
+          zip_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/website-preview.zip")
+          echo "zip_link=$zip_link" >> $GITHUB_OUTPUT
           echo "bookdown_link=$bookdown_link" >> $GITHUB_OUTPUT
           echo "tocless_link=$tocless_link" >> $GITHUB_OUTPUT
           echo "docx_link=$docx_link" >> $GITHUB_OUTPUT
@@ -203,11 +208,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Re-rendered previews from the latest commit:
-            - See [preview of Bookdown here](${{ steps.build-components.outputs.bookdown_link }})
-            - See [preview of Coursera/Leanpub version here](${{ steps.build-components.outputs.tocless_link }})
-            - Download the [preview of .docx file](${{ steps.build-components.outputs.docx_link }})
+            - :eyes: Quick [preview of course website here](${{ steps.build-components.outputs.bookdown_link }}) \*
+            - :microscope: Comprehensive [download of the course website here](${{ steps.build-components.outputs.zip_link }})
+            - Download the [.docx file](${{ steps.build-components.outputs.docx_link }})
 
-            _Updated at ${{ steps.build-components.outputs.time }} with changes from ${{ steps.build-components.outputs.commit_id }}_
+            \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
+
+            _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
           edit-mode: replace
 
       - name: Comment if no changes


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
This change is nearly identical to what I've added to the OTTR Template Website repo: https://github.com/jhudsl/OTTR_Template_Website/pull/61 

> Was trying to think of a way that a more comprehensive preview could be shown. Because at times I want to check for a change that https://htmlpreview.github.io/ can't handle -- dropdowns and font-awesome icons for example don't get shown.

> In this set up a rendered version of the website gets rendered as usually but a copy of it gets zipped up and archived so people could download it.
