### PR TITLE
Automatically open links to new tab

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -2,8 +2,8 @@ bookdown::gitbook:
   css: assets/style.css
   includes:
     before_body: assets/big-image.html
-    after_body: assets/footer.html
-  highlight: tango
+    after_body: [assets/footer.html, assets/open-new-tab.html]
+    highlight: tango
   config:
     toc:
       collapse: section

--- a/assets/open-new-tab.html
+++ b/assets/open-new-tab.html
@@ -1,0 +1,9 @@
+<script>
+  var links = document.getElementsByTagName('a');
+  var len = links.length;
+
+  for(var i=0; i<len; i++)
+  {
+    links[i].target = "_blank";
+  }
+</script>


### PR DESCRIPTION
(Used this [blogpost](https://www.bendirt.com/javascript-in-bookdown/) as a reference)

I added JS code to `assets/open-new-tab.html` inside the `<script>` tag, and pointed this file out to bookdown by placing it in the appropriate field inside `_output.yml`. 

I tested this works by running `bookdown::render_book()` and clicking on the links on the rendered HTML pages. 

https://github.com/jhudsl/OTTR_Template/assets/50791792/19f61a9e-3cd0-4612-90b0-1c80582d2601

My only question is after running `bookdown::render_book()`, I get a bunch of rendered files in `docs/`, and I'm not sure whether I need to include the below files in this PR?


![Screenshot 2024-04-08 at 12 10 51 PM](https://github.com/jhudsl/OTTR_Template/assets/50791792/f314b407-b4c3-4f8e-bfcd-774518b9263a)

