### PR TITLE
update issue templates, related automatic issue, and include in cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-course-add-to-sync.md
+++ b/.github/ISSUE_TEMPLATE/new-course-add-to-sync.md
@@ -1,0 +1,14 @@
+---
+name: Add your new course to syncs/OTTR updates
+about: Provide information about your new course (which uses the OTTR template) so that we can enroll it in OTTR updates
+title: ''
+labels: ''
+assignees: cansavvy
+
+---
+
+## What is the name of your new repository?
+<!-- The name of the repo. Ex the name of this repo is OTTR_Template -->
+
+## What username or organization is your new repository associated with?
+<!-- The name of the username or organization where the new repository is located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->

--- a/.github/ISSUE_TEMPLATE/update-course-info-for-sync.md
+++ b/.github/ISSUE_TEMPLATE/update-course-info-for-sync.md
@@ -1,0 +1,26 @@
+---
+name: Update your course's info for syncs/OTTR updates
+about: Provide information about your moved/renamed course (which uses the OTTR template) so that it can continue to be enrolled in OTTR updates
+title: ''
+labels: ''
+assignees: cansavvy
+
+---
+
+<!-- Remove headings if they are not applicable to the changes/updates you made for your repo-->
+
+## If the name of your repository was changed ...
+
+### What was the old name?
+<!-- The old/original name of the repo. Ex the name of this repo is OTTR_Template -->
+
+### What is the new name?
+<!-- The new/modified name of the repo. Ex the name of this repo is OTTR_Template -->
+
+## If the repository was moved ...
+
+### What was the original username or organization your repository was associated with?
+<!-- The old/original name of the username or organization where the new repository was located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->
+
+### What is the new username or organization your repository was associated with?
+<!-- The new/modified name of the username or organization where the new repository is located . Ex this repository is part of the jhudsl organization. A personal repository would be associated with a username instead of the organization. -->

--- a/.github/automatic-issues/update-enrollment.md
+++ b/.github/automatic-issues/update-enrollment.md
@@ -5,3 +5,4 @@ We are working on adding more features and smoothing out bugs as we go.
 If you want to receive updates from the original template to your course template, you will need to enroll this repository to the template updates by adding it to the `sync.yml` file.
 
 - [ ] [Follow these instructions](https://www.ottrproject.org/getting_started.html#9_Enroll_your_repository_for_OTTR_updates) to enroll your course repository to receive these updates.
+  - [ ] Alternatively, [open an issue in the OTTR_Template repo](https://github.com/jhudsl/OTTR_Template/issues/new?assignees=cansavvy&labels=&projects=&template=new-course-add-to-sync.md&title=), providing us with the necessary information to add the course for you.

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -40,6 +40,8 @@ jobs:
             .github/workflows/starting-course.yml \
             .github/ISSUE_TEMPLATE/course-template-problem-report.md \
             .github/ISSUE_TEMPLATE/course-template-feature-request.md \
+            .github/ISSUE_TEMPLATE/new-course-add-to-sync.md \
+            .github/ISSUE_TEMPLATE/update-course-info-for-sync.md \
             .github/PULL_REQUEST_TEMPLATE/add_to_sync_template.md \
             resources/code_output \
             resources/screenshots \


### PR DESCRIPTION
This PR addresses the second bullet point of Issue #754 , providing an issue template specific for wanting to add a course to `sync.yml`. 

Additionally 
- I've included an Issue template for when a course is renamed or moved and needs to be updated within `sync.yml`.
- Added both of these issue templates to the starting course workflow cleanup
- Added a projected link for the new issue template to the relevant automatic issue

Once these templates have been edited, approved, and merged
 - [x] I will link directly to them in documentation on ottrproject.org
 - [ ] I will make similar issue templates for OTTR_Template_Websites and OTTR_Quizzes