### PR TITLE
Do rebase for render-all too (put back what @avahoffman had)

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -83,7 +83,7 @@ jobs:
           git fetch origin
           git add --force docs/*
           git commit -m 'Render bookdown' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push -u origin main  || echo "No changes to push"
 
   render-tocless:
@@ -122,7 +122,7 @@ jobs:
           git fetch origin
           git add --force docs/no_toc*
           git commit -m 'Render toc-less' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push -u origin main  || echo "No changes to push"
 
   render-leanpub:
@@ -169,7 +169,7 @@ jobs:
           git fetch origin
           git add .
           git commit -m 'Delete manuscript folder' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push -u origin main || echo "No changes to push"
 
       - name: Run ottrpal::bookdown_to_embed_leanpub
@@ -199,7 +199,7 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Leanpub' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push --force --set-upstream origin main || echo "No changes to push"
 
   render-coursera:
@@ -244,5 +244,5 @@ jobs:
           git add --force resources/*
           git add --force docs/*
           git commit -m 'Render Coursera quizzes' || echo "No changes to commit"
-          git pull --allow-unrelated-histories --strategy-option=ours
+          git pull --rebase --set-upstream origin $branch_name --allow-unrelated-histories --strategy-option=ours
           git push -u origin main  || echo "No changes to push"


### PR DESCRIPTION
See discussion here #756 

We've decided rebase is the right call for not just preview but for all of it. Still don't know *exactly* what changed with checkout or something but this appears to be necessary. 

this will require a sync to go out and a patch OTTR release