### PR TITLE
Update config_automation.yml

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -21,9 +21,9 @@ render-website: rmd
 render-leanpub: yes
 render-coursera: no
 
-## Automate the creation of Book.txt file? TRUE/FALSE?
+## Automate the creation of Book.txt file? yes/no
 ## This is only relevant if render-leanpub is yes, otherwise it will be ignored
-make-book-txt: TRUE
+make-book-txt: yes
 
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main


### PR DESCRIPTION
## Summary 

https://github.com/fhdsl/Intro_to_Python/pull/22 made me realize the config file comment that says to set make_book_txt to TRUE/FALSE was incorrect and actually it should be set to yes/no 

When we send out the next OTTR release we will have to put additional commits on OTTR sync PRs that have suggested changes to config files. 

