### PR TITLE
jhudsl-robot is needed for syncs

### DIFF
--- a/.github/automatic-issues/update-enrollment.md
+++ b/.github/automatic-issues/update-enrollment.md
@@ -6,3 +6,6 @@ If you want to receive updates from the original template to your course templat
 
 - [ ] [Follow these instructions](https://www.ottrproject.org/getting_started.html#9_Enroll_your_repository_for_OTTR_updates) to enroll your course repository to receive these updates.
   - [ ] Alternatively, [open an issue in the OTTR_Template repo](https://github.com/jhudsl/OTTR_Template/issues/new?assignees=cansavvy&labels=&projects=&template=new-course-add-to-sync.md&title=), providing us with the necessary information to add the course for you.
+
+In order for these syncs to happen we need credentials to do so. Our `jhudsl-robot` is what you need to give access to. 
+- [ ] [Add the `jhudsl-robot` as a collaborator to your repository.](https://www.ottrproject.org/getting_started.html#5_Add_jhudsl-robot_as_a_collaborator).

--- a/.github/workflows/send-updates.yml
+++ b/.github/workflows/send-updates.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Login as github actions bot
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --local user.email "itcrtrainingnetwork@gmail.com"
+          git config --local user.name "jhudsl-robot"
 
       - name: Get the version
         id: get_tag


### PR DESCRIPTION
## Summary 

AH. So there is one place that jhudsl-robot is needed. It's for syncs. See #773 

So #728 didn't consider this part. 

We'll need to add it back to the documentation and issue template too. 

## Feedback 

I haven't tested this on anything. We need something that is external and that jhudsl-robot is given permissions to. I'll probably attempt to send to OCS or something. 