### PR TITLE
Update render-all.yml with a force push of docs

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -102,7 +102,7 @@ jobs:
           git add --force docs/*
           git commit -m 'Render course' || echo "No changes to commit"
           git status docs/*
-          git push -u origin main  || echo "No changes to push"
+          git push --force -u origin main  || echo "No changes to push"
 
   render-tocless:
     name: Render TOC-less version for Leanpub or Coursera
@@ -150,7 +150,7 @@ jobs:
           git add --force docs/no_toc*
           git commit -m 'Render toc-less' || echo "No changes to commit"
           git status docs/no_toc*
-          git push -u origin main  || echo "No changes to push"
+          git push --force -u origin main  || echo "No changes to push"
 
   render-leanpub:
     name: Finish Leanpub prep
@@ -277,4 +277,4 @@ jobs:
           git add --force docs/*
           git commit -m 'Render Coursera quizzes' || echo "No changes to commit"
           git status
-          git push -u origin main  || echo "No changes to push"
+          git push --force -u origin main  || echo "No changes to push"


### PR DESCRIPTION
##Summary 

 Sometimes rendering changes are being lost in the `docs` folder because if another branch has been pushed in the time that the render is running it hasn't pulled the changes yet. But for docs/* we don't care. We want it to render the latest and not care about what else is happening. 

This is what the logs look like even though I have it fetch not long before this. 
```
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
warning: redirecting to https://github.com/fhdsl/Containers_for_Scientists/
To https://github.com/fhdsl/Containers_for_Scientists
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/fhdsl/Containers_for_Scientists'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
No changes to push

````
This feels risky but enough of this has been happening that I think its what we need. 

`git push --force`

