### PR TITLE
Create add-authors.md

### DIFF
--- a/.github/automatic-issues/add-authors.md
+++ b/.github/automatic-issues/add-authors.md
@@ -1,0 +1,3 @@
+- [ ] Fill in the `About.Rmd` page to give credit to authors and contributors.
+
+For more information about the `About.Rmd` page, see [the ottr instructions](https://www.ottrproject.org/more_features.html#Giving_credits_to_contributors).

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -142,3 +142,11 @@ jobs:
           title: Reminder - Add to jhudsl library
           content-filepath: .github/automatic-issues/add-to-library.md
           labels: automated training issue
+
+      # Issue for reminding people to add authors
+      - name: Reminder - Add Authors
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Reminder - Add Authors
+          content-filepath: .github/automatic-issues/add-authors.md
+          labels: automated training issue


### PR DESCRIPTION
I recently added this to AnVIL_Template and thought it could be useful for OTTR_Template as well.

Older versions of `templates-to-edit.md` remind people to add authors to the index.Rmd page and About.Rmd. The current one does not mention adding authors anywhere (or at least I didn't see it anywhere).

I think it makes sense for this to be a separate issue, as I'll usually add authors towards the end, when the book is at least close to done and I have a good sense of who contributed to it, rather than at the beginning, when I'm taking care of the other stuff in `templates-to-edit.md`